### PR TITLE
Readonly input files property, property directives

### DIFF
--- a/cbrain_task/civet/portal/civet.rb
+++ b/cbrain_task/civet/portal/civet.rb
@@ -85,6 +85,8 @@ class CbrainTask::Civet < PortalTask
     verify_civet
   )
 
+  task_properties :readonly_input_files
+
   # Returns the scientific parameters common to all the CIVET
   # jobs we're about to launch
   def self.default_launch_args #:nodoc:

--- a/cbrain_task/civet_combiner/portal/civet_combiner.rb
+++ b/cbrain_task/civet_combiner/portal/civet_combiner.rb
@@ -25,9 +25,7 @@ class CbrainTask::CivetCombiner < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :no_presets => true }
-  end
+  task_properties :readonly_input_files, :no_presets
 
   def self.default_launch_args #:nodoc:
     { :civet_collection_ids => [],

--- a/cbrain_task/civet_qc/portal/civet_qc.rb
+++ b/cbrain_task/civet_qc/portal/civet_qc.rb
@@ -25,9 +25,7 @@ class CbrainTask::CivetQc < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :no_presets => true }
-  end
+  task_properties :no_presets
 
   def before_form #:nodoc:
 

--- a/cbrain_task/dcm2mnc/portal/dcm2mnc.rb
+++ b/cbrain_task/dcm2mnc/portal/dcm2mnc.rb
@@ -25,9 +25,7 @@ class CbrainTask::Dcm2mnc < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :no_presets => true, :use_parallelizer => true }
-  end
+  task_properties :no_presets, :use_parallelizer, :readonly_input_files
 
   # Returns the scientific parameters common to all the CIVET
   # jobs we're about to launch

--- a/cbrain_task/dcm2nii/portal/dcm2nii.rb
+++ b/cbrain_task/dcm2nii/portal/dcm2nii.rb
@@ -25,9 +25,7 @@ class CbrainTask::Dcm2nii < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties  :use_parallelizer, :readonly_input_files
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_bedpostx/portal/fsl_bedpostx.rb
+++ b/cbrain_task/fsl_bedpostx/portal/fsl_bedpostx.rb
@@ -25,6 +25,8 @@ class CbrainTask::FslBedpostx < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   def self.default_launch_args #:nodoc:
     {
       :fibres  => "2",

--- a/cbrain_task/fsl_bet/portal/fsl_bet.rb
+++ b/cbrain_task/fsl_bet/portal/fsl_bet.rb
@@ -27,9 +27,7 @@ class CbrainTask::FslBet < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_fast/portal/fsl_fast.rb
+++ b/cbrain_task/fsl_fast/portal/fsl_fast.rb
@@ -27,9 +27,7 @@ class CbrainTask::FslFast < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_feat/portal/fsl_feat.rb
+++ b/cbrain_task/fsl_feat/portal/fsl_feat.rb
@@ -27,11 +27,7 @@ class CbrainTask::FslFeat < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    {
-      :use_parallelizer => true
-    }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_first/portal/fsl_first.rb
+++ b/cbrain_task/fsl_first/portal/fsl_first.rb
@@ -27,11 +27,7 @@ class CbrainTask::FslFirst < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    {
-      :use_parallelizer => true
-    }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_flirt/portal/fsl_flirt.rb
+++ b/cbrain_task/fsl_flirt/portal/fsl_flirt.rb
@@ -27,6 +27,8 @@ class CbrainTask::FslFlirt < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   def self.default_launch_args #:nodoc:
     {
       :mode         => "input_ref",

--- a/cbrain_task/fsl_melodic/portal/fsl_melodic.rb
+++ b/cbrain_task/fsl_melodic/portal/fsl_melodic.rb
@@ -27,9 +27,7 @@ class CbrainTask::FslMelodic < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/fsl_probtrackx/portal/fsl_probtrackx.rb
+++ b/cbrain_task/fsl_probtrackx/portal/fsl_probtrackx.rb
@@ -4,6 +4,8 @@ class CbrainTask::FslProbtrackx < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   def self.default_launch_args #:nodoc:
     {
       :num_samples  => 1000,

--- a/cbrain_task/fsl_randomise/portal/fsl_randomise.rb
+++ b/cbrain_task/fsl_randomise/portal/fsl_randomise.rb
@@ -25,6 +25,8 @@ class CbrainTask::FslRandomise < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   def self.default_launch_args #:nodoc:
     {
       :n_perm                      => "5000",

--- a/cbrain_task/minc_convert/portal/minc_convert.rb
+++ b/cbrain_task/minc_convert/portal/minc_convert.rb
@@ -27,12 +27,7 @@ class CbrainTask::MincConvert < PortalTask
 
  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-
-  def self.properties #:nodoc:
-    {
-      :use_parallelizer => true
-    }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/mnc2nii/portal/mnc2nii.rb
+++ b/cbrain_task/mnc2nii/portal/mnc2nii.rb
@@ -27,9 +27,7 @@ class CbrainTask::Mnc2nii < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties :use_parallelizer, :readonly_input_files
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/nii2mnc/portal/nii2mnc.rb
+++ b/cbrain_task/nii2mnc/portal/nii2mnc.rb
@@ -27,9 +27,7 @@ class CbrainTask::Nii2mnc < PortalTask
 
   after_find :after_find_update_flip_params
 
-  def self.properties #:nodoc:
-    { :use_parallelizer => true }
-  end
+  task_properties :use_parallelizer, :readonly_input_files
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/nu_correct/portal/nu_correct.rb
+++ b/cbrain_task/nu_correct/portal/nu_correct.rb
@@ -25,6 +25,8 @@ class CbrainTask::NuCorrect < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   # RDOC comments here, if you want, although the method
   # is created with #:nodoc: in this template.
   def self.default_launch_args #:nodoc:

--- a/cbrain_task/recon_all/portal/recon_all.rb
+++ b/cbrain_task/recon_all/portal/recon_all.rb
@@ -27,11 +27,7 @@ class CbrainTask::ReconAll < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  def self.properties #:nodoc:
-    {
-      :use_parallelizer => true
-    }
-  end
+  task_properties :readonly_input_files, :use_parallelizer
 
   def self.default_launch_args #:nodoc:
     {

--- a/cbrain_task/recon_all_longi/portal/recon_all_longi.rb
+++ b/cbrain_task/recon_all_longi/portal/recon_all_longi.rb
@@ -25,6 +25,8 @@ class CbrainTask::ReconAllLongi < PortalTask
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  task_properties :readonly_input_files
+
   def self.default_launch_args #:nodoc:
     {
     }


### PR DESCRIPTION
Ports all self.properties methods to the new (simpler) directive version
and adds support for the new :readonly_input_files property which
indicates that a task does not alter its input files (and can thus be
executed on files the user does not have write access to).

Requires https://github.com/remibernard/cbrain/commit/aea4978b76bb121942d8139a8ca6610ab3d8234f