### PR TITLE
Improved the appearance of the CivetStudy QC view.

### DIFF
--- a/userfiles/civet_study/views/_civet_study.html.erb
+++ b/userfiles/civet_study/views/_civet_study.html.erb
@@ -26,8 +26,9 @@
   <% if @userfile.list_files(".", :directory).any? { |dir| dir.name[-3, 3] == "/QC" } %>
     <%= link_to("Show QC Data",
                 display_userfile_path(@userfile,
-                            :viewer  => "qc_file",
-                            :qc_file => "base"
+                            :viewer       => "qc_file",
+                            :qc_file      => "base",
+                            :apply_layout => "yes",
                            ),
                 :class => "action_link",
                 :target => "_blank") %>

--- a/userfiles/civet_study/views/_qc_file.html.erb
+++ b/userfiles/civet_study/views/_qc_file.html.erb
@@ -42,19 +42,37 @@
   <script>
     (function() {
       var fragment = $(<%= html_for_js(File.read(@userfile.cache_full_path.parent + qc_file)).html_safe %>);
-      var base_link_url = "/userfiles/" + <%= @userfile.id %> + "/display?apply_div=false&viewer=qc_file&qc_file=";
+      var base_link_url  = "/userfiles/" + <%= @userfile.id %> + "/display?apply_div=false&viewer=qc_file&qc_file=";
       var base_image_url = "/userfiles/" + <%= @userfile.id %> + "/content?content_loader=collection_file&arguments=";
-      var file_list = [<%= @userfile.list_files.map {|f| "\"#{f.name}\"" }.join(",").html_safe %>];
+      var file_list = [
+        <%= @userfile.list_files
+            .map(&:name)
+            .select { |name| name =~ /\.(png|jpg|jpeg|gif)$/i }
+            .map    { |name| "\"#{name}\"" }
+            .join(",\n")
+            .html_safe
+        %>
+      ];
 
       fragment.find("a").each(function() {
         this.href = base_link_url + $(this).attr("href");
       });
 
-      fragment.find("img, image").each(function() {
-        var image = this;
-        var image_src = $(this).attr("src");
-        var image_name = file_list.filter(function(f) { return f.match(new RegExp(image_src + "$")); })[0];
-        image.src = base_image_url + image_name;
+      // This code should be improved to parse the image path
+      // relative to the path of qc_file itself!
+      fragment.find("img").each(function() {
+        var image      = this;
+        var image_src  = $(image).attr("src"); // usually a relative path
+        image_src      = image_src.replace(/^[\/\.]+/,"");  // remove leading ../../../
+        var image_name = file_list.filter(function(f) {
+          return f.match(new RegExp(image_src + "$"));
+        })[0];
+        if (image_src) {
+          image.src = base_image_url + image_name;
+        } else {
+          // don't know what to do, really
+          image.src = ""
+        }
       });
 
       $("#fragment-wrapper").append(fragment);


### PR DESCRIPTION
The javscript code has been tweaked a bit to make it easier
to understandm but it's still awful and still generates
tons of spurious requests before it quicks in a fixes
all the SRC attributes of the images.

Note: to see the diffs, we also need a special modification to the userfiles_controller on the main CBRAIN project. To be forthcoming. Maybe wait until that change has been incorported in the dev branch over there before reviewing this code.

The necessary platform code is included in https://github.com/aces/cbrain/pull/393 ; so wait until that PR is merged before trying out this one.