### PR TITLE
Updating ICA-AROMA

### DIFF
--- a/cbrain_task_descriptors/ICA-AROMA.json
+++ b/cbrain_task_descriptors/ICA-AROMA.json
@@ -3,8 +3,11 @@
   "tool-version" : "0.3.1",
   "description" : "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
   "command-line" : "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]",
-  "docker-image": "mcin/ica-aroma:latest",
-  "docker-index": "http://index.docker.io",
+  "container-image" : {
+    "type" : "docker",
+    "image" : "mcin/ica-aroma:latest",
+    "index" : "http://index.docker.io"
+  },
   "schema-version" : "0.2",
   "walltime-estimate" : 5000,
   "inputs" : [{


### PR DESCRIPTION
Updates ICA-AROMA to the new container syntax.

Note that this must be used *only* after aces/cbrain#550 is merged. If used without those cbrain updates, ICA-AROMA will fail; conversely, if the old descriptor is used, it will fail with the newer cbrain version.