### PR TITLE
Updated descriptor for boutiques 0.5

### DIFF
--- a/cbrain_task_descriptors/ICA-AROMA.json
+++ b/cbrain_task_descriptors/ICA-AROMA.json
@@ -1,150 +1,205 @@
 {
-  "name" : "ICA_AROMA",
-  "tool-version" : "0.3.1",
-  "description" : "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
-  "command-line" : "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]",
-  "container-image" : {
-    "type" : "docker",
-    "image" : "mcin/ica-aroma:latest",
-    "index" : "http://index.docker.io"
-  },
-  "schema-version" : "0.4",
-  "walltime-estimate" : 5000,
-  "inputs" : [{
-    "id" : "outdir",
-    "name" : "Output directory",
-    "type" : "String",
-    "description" : "Output directory name.",
-    "optional" : false,
-    "list" : false,
-    "command-line-flag" : "-out",
-    "value-key" : "[OUTPUT_DIR]",
-    "default-value" : "AROMA_output"
-  }, {
-    "id" : "infile",
-    "name" : "Input file",
-    "type" : "File",
-    "description" : "Input file name of fMRI data (.nii.gz).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-in",
-    "value-key" : "[INPUT_FILE]",
-    "requires-inputs" : ["realignment_file", "affine_file", "warp_file"]
-  }, {
-    "id" : "affine_file",
-    "name" : "Affine registration file",
-    "type" : "File",
-    "description" : "File name of the mat-file describing the affine registration (e.g. FSL FLIRT) of the functional data to structural space (.mat file).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-affmat",
-    "value-key" : "[AFFINE_FILE]",
-    "requires-inputs" : ["infile"]
-  }, {
-    "id" : "warp_file",
-    "name" : "Non-linear registration warp file",
-    "type" : "File",
-    "description" : "File name of the warp-file describing the non-linear registration (e.g. FSL FNIRT) of the structural data to MNI152 space (.nii.gz format).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-warp",
-    "value-key" : "[WARP_FILE]",
-    "requires-inputs" : ["infile"]
-  }, {
-    "id" : "realignment_file",
-    "name" : "Realignment file",
-    "type" : "File",
-    "description" : "File name of the text file containing the six (column-wise) realignment parameters time-courses derived from volume-realignment (e.g. MCFLIRT). (Usually .par format).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-mc",
-    "value-key" : "[REALIGNMENT_FILE]",
-    "requires-inputs" : ["infile"]
-  }, {
-    "id" : "mask_file",
-    "name" : "Mask file",
-    "type" : "File",
-    "description" : "Input fMRI data should be masked (i.e. brain-extracted) or a specific mask has to be specified (-m, -mask) when running ICA-AROMA. Note the mask determined by FEAT is not recommended to be used; rather, a mask can be created via the Brain Extraction Tool of FSL (e.g. bet input output -f 0.3 -n -m -R). Not strictly required in generic mode. (Usually .nii.gz format.)",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-mask",
-    "value-key" : "[MASK_FILE]",
-    "requires-inputs" : ["infile"]
-  }, {
-    "id" : "melodic_dir",
-    "name" : "Melodic directory",
-    "type" : "File",
-    "description" : "When you have already run MELODIC you can specify the melodic directory as additional input to avoid running MELODIC again. Note that MELODIC should have been run on the fMRI data prior to temporal filtering and after spatial smoothing. Further, unless you have a good reason for doing otherwise, we advise to run MELODIC as part of ICA-AROMA so that it runs with optimal settings. (Usually .ica extension.)",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-md",
-    "value-key" : "[MELODIC_DIR]"
-  }, {
-    "id" : "feat_dir",
-    "name" : "FEAT directory",
-    "type" : "File",
-    "description" : "Runs ICA-AROMA in post-FEAT mode. In this case, only the FEAT directory has to be specified, as well as an output directory. ICA-AROMA will automatically define the appropriate files, create an appropriate mask (see ICA-AROMA manual, section 4.1) and use the melodic.ica directory if available, in case ‘MELODIC ICA data exploration’ was checked in FEAT. (.feat extension.)",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-feat",
-    "value-key" : "[FEAT_DIR]",
-    "disables-inputs" : ["realignment_file", "affine_file", "warp_file", "mask_file"]
-  }, {
-    "id" : "tr_num",
-    "name" : "TR",
-    "type" : "Number",
-    "description" : "TR in seconds. If this is not specified the TR will be extracted from the header of the fMRI file using ‘fslinfo’. In that case, make sure the TR in the header is correct!",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-tr",
-    "value-key" : "[TR_NUM]",
-    "minimum" : 0
-  }, {
-    "id" : "dims_num",
-    "name" : "Dimensionality reduction level",
-    "type" : "Number",
-    "description" : "Dimensionality reduction into a defined number of dimensions when running MELODIC (default is 0; automatic estimation).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-dim",
-    "value-key" : "[DIMS_NUM]",
-    "integer" : true,
-    "minimum" : 0
-  }, {
-    "id" : "denoising_strategy",
-    "name" : "Denoising strategy",
-    "type" : "String",
-    "value-choices" : ["no","nonaggr","aggr","both"],
-    "description" : "Type of denoising strategy (default is nonaggr). Can be \"no\" (only classification, no denoising), \"nonaggr\" (non-aggressive denoising, i.e. partial component regression; default), \"aggr\" (aggressive denoising, i.e. full component regression), \"both\" (both aggressive and non-aggressive denoising, two outputs).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-den",
-    "value-key" : "[DENOISING_STRATEGY]"
-  }],
-  "output-files" :  [{
-    "id" : "folder_out",
-    "name" : "Output folder",
-    "description" : "A folder containing the output files for ICA-AROMA (see ICA-AROMA manual, sec. 6). Should include a denoised fMRI data file (.nii.gz), text files indicating classification and feature results, and Melodic-related files (spatial maps in .nii.gz, a mask in .nii.gz, and the .ica output directory).",
-    "path-template" : "[OUTPUT_DIR]",
-    "list" : false,
-    "optional" : false
-  }],
-  "groups" : [{
-    "id" : "input_data_group",
-    "name" : "Input Data",
-    "description" : "Either input a .nii.gz file or a Feat directory. The former allows running ICA-AROMA in generic mode; the latter runs it in Feat mode.",
-    "members" : ["infile","feat_dir"],
-    "one-is-required" : true,
-    "mutually-exclusive" : true
-  }, {
-    "id" : "generic_mode_group",
-    "name" : "Generic Mode Parameters",
-    "description" : "Input files used in generic mode. The realignment, affine registration, and warp files are required in this mode.",
-    "members" : ["realignment_file","affine_file","warp_file","mask_file"]
-  }, {
-    "id" : "optional_args_group",
-    "name" : "Optional Parameters",
-    "description" : "Optional parameters that can be specified in either mode of ICA-AROMA.",
-    "members" : ["tr_num","denoising_strategy","dims_num","melodic_dir"]
-  }]
+    "tool-version": "0.3.1", 
+    "name": "ICA_AROMA", 
+    "command-line": "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]", 
+    "inputs": [
+        {
+            "command-line-flag": "-out", 
+            "description": "Output directory name.", 
+            "default-value": "AROMA_output", 
+            "value-key": "[OUTPUT_DIR]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "outdir", 
+            "name": "Output directory"
+        }, 
+        {
+            "command-line-flag": "-in", 
+            "description": "Input file name of fMRI data (.nii.gz).", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file"
+            ], 
+            "optional": true, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "command-line-flag": "-affmat", 
+            "description": "File name of the mat-file describing the affine registration (e.g. FSL FLIRT) of the functional data to structural space (.mat file).", 
+            "value-key": "[AFFINE_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "affine_file", 
+            "name": "Affine registration file"
+        }, 
+        {
+            "command-line-flag": "-warp", 
+            "description": "File name of the warp-file describing the non-linear registration (e.g. FSL FNIRT) of the structural data to MNI152 space (.nii.gz format).", 
+            "value-key": "[WARP_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "warp_file", 
+            "name": "Non-linear registration warp file"
+        }, 
+        {
+            "command-line-flag": "-mc", 
+            "description": "File name of the text file containing the six (column-wise) realignment parameters time-courses derived from volume-realignment (e.g. MCFLIRT). (Usually .par format).", 
+            "value-key": "[REALIGNMENT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "realignment_file", 
+            "name": "Realignment file"
+        }, 
+        {
+            "command-line-flag": "-mask", 
+            "description": "Input fMRI data should be masked (i.e. brain-extracted) or a specific mask has to be specified (-m, -mask) when running ICA-AROMA. Note the mask determined by FEAT is not recommended to be used; rather, a mask can be created via the Brain Extraction Tool of FSL (e.g. bet input output -f 0.3 -n -m -R). Not strictly required in generic mode. (Usually .nii.gz format.)", 
+            "value-key": "[MASK_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "requires-inputs": [
+                "infile"
+            ], 
+            "optional": true, 
+            "id": "mask_file", 
+            "name": "Mask file"
+        }, 
+        {
+            "command-line-flag": "-md", 
+            "description": "When you have already run MELODIC you can specify the melodic directory as additional input to avoid running MELODIC again. Note that MELODIC should have been run on the fMRI data prior to temporal filtering and after spatial smoothing. Further, unless you have a good reason for doing otherwise, we advise to run MELODIC as part of ICA-AROMA so that it runs with optimal settings. (Usually .ica extension.)", 
+            "value-key": "[MELODIC_DIR]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "melodic_dir", 
+            "name": "Melodic directory"
+        }, 
+        {
+            "command-line-flag": "-feat", 
+            "description": "Runs ICA-AROMA in post-FEAT mode. In this case, only the FEAT directory has to be specified, as well as an output directory. ICA-AROMA will automatically define the appropriate files, create an appropriate mask (see ICA-AROMA manual, section 4.1) and use the melodic.ica directory if available, in case \u2018MELODIC ICA data exploration\u2019 was checked in FEAT. (.feat extension.)", 
+            "value-key": "[FEAT_DIR]", 
+            "type": "File", 
+            "list": false, 
+            "disables-inputs": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file", 
+                "mask_file"
+            ], 
+            "optional": true, 
+            "id": "feat_dir", 
+            "name": "FEAT directory"
+        }, 
+        {
+            "command-line-flag": "-tr", 
+            "description": "TR in seconds. If this is not specified the TR will be extracted from the header of the fMRI file using \u2018fslinfo\u2019. In that case, make sure the TR in the header is correct!", 
+            "value-key": "[TR_NUM]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 0, 
+            "optional": true, 
+            "id": "tr_num", 
+            "name": "TR"
+        }, 
+        {
+            "command-line-flag": "-dim", 
+            "description": "Dimensionality reduction into a defined number of dimensions when running MELODIC (default is 0; automatic estimation).", 
+            "value-key": "[DIMS_NUM]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 0, 
+            "integer": true, 
+            "optional": true, 
+            "id": "dims_num", 
+            "name": "Dimensionality reduction level"
+        }, 
+        {
+            "command-line-flag": "-den", 
+            "description": "Type of denoising strategy (default is nonaggr). Can be \"no\" (only classification, no denoising), \"nonaggr\" (non-aggressive denoising, i.e. partial component regression; default), \"aggr\" (aggressive denoising, i.e. full component regression), \"both\" (both aggressive and non-aggressive denoising, two outputs).", 
+            "value-key": "[DENOISING_STRATEGY]", 
+            "optional": true, 
+            "list": false, 
+            "value-choices": [
+                "no", 
+                "nonaggr", 
+                "aggr", 
+                "both"
+            ], 
+            "type": "String", 
+            "id": "denoising_strategy", 
+            "name": "Denoising strategy"
+        }
+    ], 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "mcin/ica-aroma:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "description": "Either input a .nii.gz file or a Feat directory. The former allows running ICA-AROMA in generic mode; the latter runs it in Feat mode.", 
+            "one-is-required": true, 
+            "mutually-exclusive": true, 
+            "members": [
+                "infile", 
+                "feat_dir"
+            ], 
+            "id": "input_data_group", 
+            "name": "Input Data"
+        }, 
+        {
+            "description": "Input files used in generic mode. The realignment, affine registration, and warp files are required in this mode.", 
+            "id": "generic_mode_group", 
+            "members": [
+                "realignment_file", 
+                "affine_file", 
+                "warp_file", 
+                "mask_file"
+            ], 
+            "name": "Generic Mode Parameters"
+        }, 
+        {
+            "description": "Optional parameters that can be specified in either mode of ICA-AROMA.", 
+            "id": "optional_args_group", 
+            "members": [
+                "tr_num", 
+                "denoising_strategy", 
+                "dims_num", 
+                "melodic_dir"
+            ], 
+            "name": "Optional Parameters"
+        }
+    ], 
+    "output-files": [
+        {
+            "description": "A folder containing the output files for ICA-AROMA (see ICA-AROMA manual, sec. 6). Should include a denoised fMRI data file (.nii.gz), text files indicating classification and feature results, and Melodic-related files (spatial maps in .nii.gz, a mask in .nii.gz, and the .ica output directory).", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR]", 
+            "name": "Output folder"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 5000
+    }, 
+    "description": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data."
 }

--- a/cbrain_task_descriptors/fsl_anat.json
+++ b/cbrain_task_descriptors/fsl_anat.json
@@ -1,189 +1,238 @@
 {
-  "name" : "fsl_anat",
-  "tool-version" : "5.0.0",
-  "description" : "General pipeline for processing anatomical images (e.g. T1-weighted scans) via FSL tools. The stages include reorienting the images to the standard (MNI) orientation [fslreorient2std], automatically cropping the image [robustfov], bias-field correction (RF/B1-inhomogeneity-correction) [FAST], registration to standard space (linear and non-linear) [FLIRT and FNIRT], brain-extraction [FNIRT-based or BET], tissue-type segmentation [FAST], and subcortical structure segmentation [FIRST]",
-  "command-line" : "fsl_anat [INPUT_FILE] [INPUT_DIR] [OUTPUT_DIR] [CLOBBER_FLAG] [WEAKBIAS_FLAG] [NO_REORIENT_FLAG] [NO_CROP_FLAG] [NO_BIAS_FLAG] [NO_REGISTRATION_FLAG] [NO_NONLINEAR_REG_FLAG] [NO_SEG_FLAG] [NO_SUBCORTSEG_FLAG] [NO_SEARCH_FLAG] [NO_CLEANUP_FLAG] [BIAS_FIELD_SMOOTHING_VAL] [IMAGE_TYPE] [BET_F_PARAM]",
-  "schema-version" : "0.4",
-  "walltime-estimate" : 16000,
-  "inputs" : [{
-    "id" : "infile",
-    "name" : "Input file",
-    "type" : "File",
-    "description" : "Input image file (for single-image use), such as .nii.gz. Either this or an input dir (-d) must be specified, but not both.",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-i",
-    "value-key" : "[INPUT_FILE]"
-  }, {
-    "id" : "indir",
-    "name" : "Input Dir",
-    "type" : "File",
-    "description" : "Existing input directory (.anat extension) where this script will be run in place. Either this or an input file (-i) must be specified, but not both.",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-d",
-    "value-key" : "[INPUT_DIR]"
-  }, {
-    "id" : "outdir",
-    "name" : "Output directory",
-    "type" : "String",
-    "description" : "Specifies the output folder name. Note that the .anat extension is automatically appended.",
-    "optional" : false,
-    "list" : false,
-    "command-line-flag" : "-o",
-    "default-value" : "output_results",
-    "value-key" : "[OUTPUT_DIR]"
-  }, {
-    "id" : "clobber_flag",
-    "name" : "Clobber flag",
-    "type" : "Flag",
-    "description" : "If .anat directory exist (as specified by -o or default from -i) then delete it and make a new one.",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--clobber",
-    "value-key" : "[CLOBBER_FLAG]"
-  }, {
-    "id" : "weak_bias",
-    "name" : "Weak bias flag",
-    "type" : "Flag",
-    "description" : "Used for images with little and/or smooth bias fields. For images acquired using birdcage coils or on 1.5T scanners, the --weakbias option will be faster and may produce equally good results.",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--weakbias",
-    "value-key" : "[WEAKBIAS_FLAG]"
-  }, {
-    "id" : "no_reorient_flag",
-    "name" : "No reorienation flag",
-    "type" : "Flag",
-    "description" : "Turn off step that does reorientation 2 standard (fslreorient2std).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--noreorient",
-    "value-key" : "[NO_REORIENT_FLAG]"
-  }, {
-    "id" : "no_crop_flag",
-    "name" : "No automated cropping flag",
-    "type" : "Flag",
-    "description" : "Turn off step that does automated cropping (robustfov).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nocrop",
-    "value-key" : "[NO_CROP_FLAG]"
-  }, {
-    "id" : "no_bias_flag",
-    "name" : "No bias field correction flag",
-    "type" : "Flag",
-    "description" : "Turn off steps that do bias field correction (via FAST).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nobias",
-    "value-key" : "[NO_BIAS_FLAG]"
-  }, {
-    "id" : "no_reg_flag",
-    "name" : "No registration flag",
-    "type" : "Flag",
-    "description" : "Turn off steps that do registration to standard (FLIRT and FNIRT).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--noreg",
-    "value-key" : "[NO_REGISTRATION_FLAG]"
-  }, {
-    "id" : "no_nonlin_reg_flag",
-    "name" : "No non-linear registration flag",
-    "type" : "Flag",
-    "description" : "Turn off step that does non-linear registration (FNIRT).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nononlinreg",
-    "value-key" : "[NO_NONLINEAR_REG_FLAG]"
-  }, {
-    "id" : "no_seg_flag",
-    "name" : "No tissue-type segmentation flag",
-    "type" : "Flag",
-    "description" : "Turn off step that does tissue-type segmentation (FAST).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--noseg",
-    "value-key" : "[NO_SEG_FLAG]"
-  }, {
-    "id" : "no_subcort_seg_flag",
-    "name" : "No subcortical segmentation flag",
-    "type" : "Flag",
-    "description" : "Turn off step that does sub-cortical segmentation (FIRST).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nosubcortseg",
-    "value-key" : "[NO_SUBCORTSEG_FLAG]"
-  }, {
-    "id" : "no_search_flag",
-    "name" : "No search in linear registration flag",
-    "type" : "Flag",
-    "description" : "Specify that linear registration uses the -nosearch option (FLIRT).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nosearch",
-    "value-key" : "[NO_SEARCH_FLAG]"
-  }, {
-    "id" : "no_cleanup_flag",
-    "name" : "No cleanup flag",
-    "type" : "Flag",
-    "description" : "Do not remove intermediate files.",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--nocleanup",
-    "value-key" : "[NO_CLEANUP_FLAG]"
-  }, {
-    "id" : "bias_field_smoothing_val",
-    "name" : "Bias field smoothing value",
-    "type" : "Number",
-    "description" : "Specify the value for bias field smoothing (the -l option in FAST).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "-s",
-    "value-key" : "[BIAS_FIELD_SMOOTHING_VAL]"
-  }, {
-    "id" : "image_type",
-    "name" : "Image type",
-    "type" : "String",
-    "description" : "Specify the type of image (choose one of T1 T2 PD - default is T1).",
-    "optional" : true,
-    "value-choices" : ["T1", "T2", "PD"],
-    "list" : false,
-    "command-line-flag" : "-t",
-    "value-key" : "[IMAGE_TYPE]"
-  }, {
-    "id" : "bet_f_param",
-    "name" : "F-parameter value for BET",
-    "type" : "Number",
-    "description" : "specify the f parameter for BET (only used if not running non-linear reg and also wanting brain extraction done).",
-    "optional" : true,
-    "list" : false,
-    "command-line-flag" : "--betfparam",
-    "requires-inputs" : ["no_nonlin_reg_flag"],
-    "command-line-flag-separator" : "=",
-    "value-key" : "[BET_F_PARAM]",
-    "minimum" : 0,
-    "maximum" : 1
-  }],
-  "output-files" :  [{
-    "id" : "folder_out",
-    "name" : "Output folder",
-    "description" : "A folder containing the output files for fsl_anat. Includes outputs for the images, reorientation, cropping, bias correction, registration, brain extraction, and segmentation.",
-    "path-template" : "[OUTPUT_DIR].anat",
-    "list" : false,
-    "optional" : false
-  }],
-  "groups" : [{
-    "id" : "group_1",
-    "name" : "Input Data",
-    "description" : "Either a single structural image file (e.g. .nii.gz) or directory (.anat extension) may be given as input",
-    "members" : ["infile", "indir"],
-    "one-is-required" : true,
-    "mutually-exclusive" : true
-  }, {
-    "id" : "group_2",
-    "name" : "Optional Parameters",
-    "description" : "Parameters for controlling the execution of the fsl_anat task",
-    "members" : ["clobber_flag","weak_bias","no_reorient_flag","no_crop_flag","no_bias_flag","no_reg_flag","no_nonlin_reg_flag","no_seg_flag","no_subcort_seg_flag","no_search_flag","no_cleanup_flag","bias_field_smoothing_val","image_type","bet_f_param"]
-  }]
+    "tool-version": "5.0.0", 
+    "name": "fsl_anat", 
+    "command-line": "fsl_anat [INPUT_FILE] [INPUT_DIR] [OUTPUT_DIR] [CLOBBER_FLAG] [WEAKBIAS_FLAG] [NO_REORIENT_FLAG] [NO_CROP_FLAG] [NO_BIAS_FLAG] [NO_REGISTRATION_FLAG] [NO_NONLINEAR_REG_FLAG] [NO_SEG_FLAG] [NO_SUBCORTSEG_FLAG] [NO_SEARCH_FLAG] [NO_CLEANUP_FLAG] [BIAS_FIELD_SMOOTHING_VAL] [IMAGE_TYPE] [BET_F_PARAM]", 
+    "inputs": [
+        {
+            "command-line-flag": "-i", 
+            "description": "Input image file (for single-image use), such as .nii.gz. Either this or an input dir (-d) must be specified, but not both.", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "command-line-flag": "-d", 
+            "description": "Existing input directory (.anat extension) where this script will be run in place. Either this or an input file (-i) must be specified, but not both.", 
+            "value-key": "[INPUT_DIR]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "indir", 
+            "name": "Input Dir"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "Specifies the output folder name. Note that the .anat extension is automatically appended.", 
+            "default-value": "output_results", 
+            "value-key": "[OUTPUT_DIR]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "outdir", 
+            "name": "Output directory"
+        }, 
+        {
+            "command-line-flag": "--clobber", 
+            "description": "If .anat directory exist (as specified by -o or default from -i) then delete it and make a new one.", 
+            "value-key": "[CLOBBER_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "clobber_flag", 
+            "name": "Clobber flag"
+        }, 
+        {
+            "command-line-flag": "--weakbias", 
+            "description": "Used for images with little and/or smooth bias fields. For images acquired using birdcage coils or on 1.5T scanners, the --weakbias option will be faster and may produce equally good results.", 
+            "value-key": "[WEAKBIAS_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "weak_bias", 
+            "name": "Weak bias flag"
+        }, 
+        {
+            "command-line-flag": "--noreorient", 
+            "description": "Turn off step that does reorientation 2 standard (fslreorient2std).", 
+            "value-key": "[NO_REORIENT_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_reorient_flag", 
+            "name": "No reorienation flag"
+        }, 
+        {
+            "command-line-flag": "--nocrop", 
+            "description": "Turn off step that does automated cropping (robustfov).", 
+            "value-key": "[NO_CROP_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_crop_flag", 
+            "name": "No automated cropping flag"
+        }, 
+        {
+            "command-line-flag": "--nobias", 
+            "description": "Turn off steps that do bias field correction (via FAST).", 
+            "value-key": "[NO_BIAS_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_bias_flag", 
+            "name": "No bias field correction flag"
+        }, 
+        {
+            "command-line-flag": "--noreg", 
+            "description": "Turn off steps that do registration to standard (FLIRT and FNIRT).", 
+            "value-key": "[NO_REGISTRATION_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_reg_flag", 
+            "name": "No registration flag"
+        }, 
+        {
+            "command-line-flag": "--nononlinreg", 
+            "description": "Turn off step that does non-linear registration (FNIRT).", 
+            "value-key": "[NO_NONLINEAR_REG_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_nonlin_reg_flag", 
+            "name": "No non-linear registration flag"
+        }, 
+        {
+            "command-line-flag": "--noseg", 
+            "description": "Turn off step that does tissue-type segmentation (FAST).", 
+            "value-key": "[NO_SEG_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_seg_flag", 
+            "name": "No tissue-type segmentation flag"
+        }, 
+        {
+            "command-line-flag": "--nosubcortseg", 
+            "description": "Turn off step that does sub-cortical segmentation (FIRST).", 
+            "value-key": "[NO_SUBCORTSEG_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_subcort_seg_flag", 
+            "name": "No subcortical segmentation flag"
+        }, 
+        {
+            "command-line-flag": "--nosearch", 
+            "description": "Specify that linear registration uses the -nosearch option (FLIRT).", 
+            "value-key": "[NO_SEARCH_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_search_flag", 
+            "name": "No search in linear registration flag"
+        }, 
+        {
+            "command-line-flag": "--nocleanup", 
+            "description": "Do not remove intermediate files.", 
+            "value-key": "[NO_CLEANUP_FLAG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_cleanup_flag", 
+            "name": "No cleanup flag"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Specify the value for bias field smoothing (the -l option in FAST).", 
+            "value-key": "[BIAS_FIELD_SMOOTHING_VAL]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "bias_field_smoothing_val", 
+            "name": "Bias field smoothing value"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Specify the type of image (choose one of T1 T2 PD - default is T1).", 
+            "value-key": "[IMAGE_TYPE]", 
+            "type": "String", 
+            "list": false, 
+            "value-choices": [
+                "T1", 
+                "T2", 
+                "PD"
+            ], 
+            "optional": true, 
+            "id": "image_type", 
+            "name": "Image type"
+        }, 
+        {
+            "command-line-flag": "--betfparam", 
+            "description": "specify the f parameter for BET (only used if not running non-linear reg and also wanting brain extraction done).", 
+            "value-key": "[BET_F_PARAM]", 
+            "type": "Number", 
+            "list": false, 
+            "requires-inputs": [
+                "no_nonlin_reg_flag"
+            ], 
+            "maximum": 1, 
+            "minimum": 0, 
+            "command-line-flag-separator": "=", 
+            "optional": true, 
+            "id": "bet_f_param", 
+            "name": "F-parameter value for BET"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "description": "Either a single structural image file (e.g. .nii.gz) or directory (.anat extension) may be given as input", 
+            "one-is-required": true, 
+            "mutually-exclusive": true, 
+            "members": [
+                "infile", 
+                "indir"
+            ], 
+            "id": "group_1", 
+            "name": "Input Data"
+        }, 
+        {
+            "description": "Parameters for controlling the execution of the fsl_anat task", 
+            "id": "group_2", 
+            "members": [
+                "clobber_flag", 
+                "weak_bias", 
+                "no_reorient_flag", 
+                "no_crop_flag", 
+                "no_bias_flag", 
+                "no_reg_flag", 
+                "no_nonlin_reg_flag", 
+                "no_seg_flag", 
+                "no_subcort_seg_flag", 
+                "no_search_flag", 
+                "no_cleanup_flag", 
+                "bias_field_smoothing_val", 
+                "image_type", 
+                "bet_f_param"
+            ], 
+            "name": "Optional Parameters"
+        }
+    ], 
+    "output-files": [
+        {
+            "description": "A folder containing the output files for fsl_anat. Includes outputs for the images, reorientation, cropping, bias correction, registration, brain extraction, and segmentation.", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR].anat", 
+            "name": "Output folder"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 16000
+    }, 
+    "description": "General pipeline for processing anatomical images (e.g. T1-weighted scans) via FSL tools. The stages include reorienting the images to the standard (MNI) orientation [fslreorient2std], automatically cropping the image [robustfov], bias-field correction (RF/B1-inhomogeneity-correction) [FAST], registration to standard space (linear and non-linear) [FLIRT and FNIRT], brain-extraction [FNIRT-based or BET], tissue-type segmentation [FAST], and subcortical structure segmentation [FIRST]"
 }

--- a/cbrain_task_descriptors/fsl_bet.json
+++ b/cbrain_task_descriptors/fsl_bet.json
@@ -1,291 +1,355 @@
 {
-	"name" : "fsl_bet",
-	"tool-version" : "1.0.0",
-	"description" : "Automated brain extraction tool for FSL",
-	"command-line" : "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]",
-	"schema-version" : "0.4",
-	"inputs" : [{
-		"id" : "infile",
-		"name" : "Input file",
-		"type" : "File",
-		"description" : "Input image (e.g. img.nii.gz)",
-		"optional": false,
-		"value-key" : "[INPUT_FILE]"
-	}, {
-		"id" : "maskfile",
-		"name" : "Mask file",
-		"type" : "String",
-		"description" : "Output brain mask (e.g. img_bet.nii.gz)",
-		"optional": false,
-		"value-key" : "[MASK]"
-	}, {
-		"id" : "fractional_intensity",
-		"name" : "Fractional intensity threshold",
-		"type" : "Number",
-		"description" : "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates",
-		"command-line-flag": "-f",
-		"optional": true,
-		"value-key" : "[FRACTIONAL_INTENSITY]",
-		"integer" : false,
-		"minimum" : 0,
-		"maximum" : 1
-	}, {
-		"id" : "vg_fractional_intensity",
-		"name" : "Vertical gradient fractional intensity threshold",
-		"type" : "Number",
-		"description" : "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top",
-		"command-line-flag": "-g",
-		"optional": true,
-		"value-key" : "[VERTICAL_GRADIENT]",
-		"integer" : false,
-		"minimum" : -1,
-		"maximum" : 1
-	}, {
-		"id" : "center_of_gravity",
-		"name" : "Center of gravity vector",
-		"type" : "Number",
-		"description" : "The xyz coordinates of the center of gravity (voxels, not mm) of initial mesh surface. Must have exactly three numerical entries in the list (3-vector).",
-		"command-line-flag": "-c",
-		"optional": true,
-		"value-key" : "[CENTER_OF_GRAVITY]",
-		"list" : true,
-		"min-list-entries" : 3,
-		"max-list-entries" : 3
-	}, {
-		"id" : "overlay_flag",
-		"name" : "Overlay flag",
-		"type" : "Flag",
-		"description" : "Generate brain surface outline overlaid onto original image",
-		"command-line-flag": "-o",
-		"optional": true,
-		"value-key" : "[OVERLAY_FLAG]"
-	}, {
-		"id" : "binary_mask_flag",
-		"name" : "Binary mask flag",
-		"type" : "Flag",
-		"description" : "Generate binary brain mask",
-		"command-line-flag": "-m",
-		"optional": true,
-		"value-key" : "[BINARY_MASK_FLAG]"
-	}, {
-		"id" : "approx_skull_flag",
-		"name" : "Approximate skull flag",
-		"type" : "Flag",
-		"description" : "Generate rough skull image (not as clean as betsurf)",
-		"command-line-flag": "-s",
-		"optional": true,
-		"value-key" : "[APPROX_SKULL_FLAG]"
-	}, {
-		"id" : "no_seg_output_flag",
-		"name" : "No segmented brain image flag",
-		"type" : "Flag",
-		"description" : "Don't generate segmented brain image output",
-		"command-line-flag": "-n",
-		"optional": true,
-		"value-key" : "[NO_SEG_OUTPUT_FLAG]"
-	}, {
-		"id" : "vtk_mesh",
-		"name" : "VTK format brain surface mesh flag",
-		"type" : "Flag",
-		"description" : "Generate brain surface as mesh in .vtk format",
-		"command-line-flag": "-e",
-		"optional": true,
-		"value-key" : "[VTK_VIEW_FLAG]"
-	}, {
-		"id" : "head_radius",
-		"name" : "Head Radius",
-		"type" : "Number",
-		"description" : "head radius (mm not voxels); initial surface sphere is set to half of this",
-		"command-line-flag": "-r",
-		"optional": true,
-		"value-key" : "[HEAD_RADIUS]"
-	}, {
-		"id" : "thresholding_flag",
-		"name" : "Threshold segmented image flag",
-		"type" : "Flag",
-		"description" : "Apply thresholding to segmented brain image and mask",
-		"command-line-flag": "-t",
-		"optional": true,
-		"value-key" : "[THRESHOLDING_FLAG]"
-	}, {
-		"id" : "robust_iters_flag",
-		"name" : "Robust iterations flag",
-		"type" : "Flag",
-		"description" : "More robust brain center estimation, by iterating BET with a changing center-of-gravity.",
-		"command-line-flag": "-R",
-		"optional": true,
-		"value-key" : "[ROBUST_ITERS_FLAG]"
-	}, {
-		"id" : "residual_optic_cleanup_flag",
-		"name" : "Residual optic cleanup flag",
-		"type" : "Flag",
-		"description" : "This attempts to cleanup residual eye and optic nerve voxels which bet2 can sometimes leave behind. This can be useful when running SIENA or SIENAX, for example. Various stages involving standard-space masking, morphpological operations and thresholdings are combined to produce a result which can often give better results than just running bet2.",
-		"command-line-flag": "-S",
-		"optional": true,
-		"value-key" : "[RES_OPTIC_CLEANUP_FLAG]"
-	}, {
-		"id" : "reduce_bias_flag",
-		"name" : "Bias reduction flag",
-		"type" : "Flag",
-		"description" : "This attempts to reduce image bias, and residual neck voxels. This can be useful when running SIENA or SIENAX, for example. Various stages involving FAST segmentation-based bias field removal and standard-space masking are combined to produce a result which can often give better results than just running bet2.",
-		"command-line-flag": "-B",
-		"optional": true,
-		"value-key" : "[REDUCE_BIAS_FLAG]"
-	}, {
-		"id" : "slice_padding_flag",
-		"name" : "Slice padding flag",
-		"type" : "Flag",
-		"description" : "This can improve the brain extraction if only a few slices are present in the data (i.e., a small field of view in the Z direction). This is achieved by padding the end slices in both directions, copying the end slices several times, running bet2 and then removing the added slices.",
-		"command-line-flag": "-Z",
-		"optional": true,
-		"value-key" : "[SLICE_PADDING_FLAG]"
-	}, {
-		"id" : "whole_set_mask_flag",
-		"name" : "Mask-whole-set flag",
-		"type" : "Flag",
-		"description" : "This option uses bet2 to determine a brain mask on the basis of the first volume in a 4D data set, and applies this to the whole data set. This is principally intended for use on FMRI data, for example to remove eyeballs. Because it is normally important (in this application) that masking be liberal (ie that there be little risk of cutting out valid brain voxels) the -f threshold is reduced to 0.3, and also the brain mask is \"dilated\" slightly before being used.",
-		"command-line-flag": "-F",
-		"optional": true,
-		"value-key" : "[MASK_WHOLE_SET_FLAG]"
-	}, {
-		"id" : "additional_surfaces_flag",
-		"name" : "Additional surfaces flag",
-		"type" : "Flag",
-		"description" : "This runs both bet2 and betsurf programs in order to get the additional skull and scalp surfaces created by betsurf. This involves registering to standard space in order to allow betsurf to find the standard space masks it needs.",
-		"command-line-flag": "-A",
-		"optional": true,
-		"value-key" : "[ADD_SURFACES_FLAG]"
-	}, {
-		"id" : "additional_surfaces_t2",
-		"name" : "Additional surfaces with T2",
-		"type" : "File",
-		"description" : "This is the same as -A except that a T2 image is also input, to further improve the estimated skull and scalp surfaces. As well as carrying out the standard space registration this also registers the T2 to the T1 input image.",
-		"command-line-flag": "-A2",
-		"optional": true,
-		"value-key" : "[ADD_SURFACES_T2]"
-	}, {
-		"id" : "verbose_flag",
-		"name" : "Verbose Flag",
-		"type" : "Flag",
-		"description" : "Switch on diagnostic messages",
-		"command-line-flag": "-v",
-		"optional": true,
-		"value-key" : "[VERBOSE_FLAG]"
-	}, {
-		"id" : "debug_flag",
-		"name" : "Debug Flag",
-		"type" : "Flag",
-		"description" : "Don't delete temporary intermediate images",
-		"command-line-flag": "-d",
-		"optional": true,
-		"value-key" : "[DEBUG_FLAG]"
-	}],
-	"output-files" :  [{
-		"id" : "outfile",
-		"name" : "Output mask file",
-		"description" : "Main default mask output of BET",
-		"path-template" : "[MASK].nii.gz",
-		"optional" : true
-	}, {
-		"id" : "binary_mask",
-		"name" : "Output binary mask file",
-		"description" : "Binary mask file (from -m option)",
-		"path-template" : "[MASK]_mask.nii.gz",
-		"optional" : true
-  }, {
-		"id" : "overlay_file",
-		"name" : "Surface overlay file",
-		"description" : "Overlaid brain surface onto original image",
-		"path-template" : "[MASK]_overlay.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "approx_skull_img",
-		"name" : "Approximate skull file",
-		"description" : "Approximate skull image file",
-		"path-template" : "[MASK]_skull.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "output_vtk_mesh",
-		"name" : "VTK mesh",
-		"description" : "Mesh in VTK format",
-		"path-template" : "[MASK]_mesh.vtk",
-		"optional" : true
-	}, {
-		"id" : "skull_mask",
-		"name" : "Skull mask image",
-		"description" : "Output mask for skull image",
-		"path-template" : "[MASK]_skull_mask.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_inskull_mask",
-		"name" : "Output in-skull mask file",
-		"description" : "The in-skull mask file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_inskull_mask.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_inskull_mesh",
-		"name" : "Output in-skull mesh file",
-		"description" : "The in-skull mesh file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_inskull_mesh.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_inskull_off",
-		"name" : "Output in-skull mesh off file",
-		"description" : "The in-skull mesh .off file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_inskull_mesh.off",
-		"optional" : true
-	}, {
-		"id" : "out_outskin_mask",
-		"name" : "Output out-skin mask file",
-		"description" : "The out-skin mask file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskin_mask.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_outskin_mesh",
-		"name" : "Output out-skin mesh file",
-		"description" : "The out-skin mesh file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskin_mesh.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_outskin_off",
-		"name" : "Output out-skin mesh off file",
-		"description" : "The out-skin mesh .off file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskin_mesh.off",
-		"optional" : true
-	}, {
-		"id" : "out_outskull_mask",
-		"name" : "Output out-skull mask file",
-		"description" : "The out-skull mask file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskull_mask.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_outskull_mesh",
-		"name" : "Output out-skull mesh file",
-		"description" : "The out-skull mesh file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskull_mesh.nii.gz",
-		"optional" : true
-	}, {
-		"id" : "out_outskull_off",
-		"name" : "Output out-skull mesh off file",
-		"description" : "The out-skull mesh .off file from betsurf (from -A or -A2)",
-		"path-template" : "[MASK]_outskull_mesh.off",
-		"optional" : true
-	}],
-	"groups" : [{
-		"id" : "optional_params_group",
-		"name" : "Main Program Parameters",
-		"description" : "Specify parameters that alter the default BET functionality",
-		"members" : ["fractional_intensity", "vg_fractional_intensity", "center_of_gravity", "overlay_flag", "binary_mask_flag", "approx_skull_flag", "no_seg_output_flag", "vtk_mesh", "head_radius", "thresholding_flag"]
-	}, {
-		"id" : "variational_params_group",
-		"name" : "Variations on Default Functionality",
-		"description" : "Mutually exclusive options that specify variations on how BET should be run.",
-		"members" : ["robust_iters_flag", "residual_optic_cleanup_flag", "reduce_bias_flag", "slice_padding_flag", "whole_set_mask_flag", "additional_surfaces_flag", "additional_surfaces_t2"],
-		"mutually-exclusive" : true
-	}, {
-		"id" : "miscellaneous_params_group",
-		"name" : "Miscellaneous Parameters",
-		"description" : "Optional miscellaneous parameters when running BET",
-		"members" : ["verbose_flag", "debug_flag"]
-	}]
+    "tool-version": "1.0.0", 
+    "name": "fsl_bet", 
+    "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]", 
+    "inputs": [
+        {
+            "description": "Input image (e.g. img.nii.gz)", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "description": "Output brain mask (e.g. img_bet.nii.gz)", 
+            "value-key": "[MASK]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "maskfile", 
+            "name": "Mask file"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates", 
+            "value-key": "[FRACTIONAL_INTENSITY]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": 0, 
+            "integer": false, 
+            "optional": true, 
+            "id": "fractional_intensity", 
+            "name": "Fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-g", 
+            "description": "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top", 
+            "value-key": "[VERTICAL_GRADIENT]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": -1, 
+            "integer": false, 
+            "optional": true, 
+            "id": "vg_fractional_intensity", 
+            "name": "Vertical gradient fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-c", 
+            "description": "The xyz coordinates of the center of gravity (voxels, not mm) of initial mesh surface. Must have exactly three numerical entries in the list (3-vector).", 
+            "value-key": "[CENTER_OF_GRAVITY]", 
+            "type": "Number", 
+            "list": true, 
+            "max-list-entries": 3, 
+            "optional": true, 
+            "id": "center_of_gravity", 
+            "min-list-entries": 3, 
+            "name": "Center of gravity vector"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "Generate brain surface outline overlaid onto original image", 
+            "value-key": "[OVERLAY_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "overlay_flag", 
+            "name": "Overlay flag"
+        }, 
+        {
+            "command-line-flag": "-m", 
+            "description": "Generate binary brain mask", 
+            "value-key": "[BINARY_MASK_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "binary_mask_flag", 
+            "name": "Binary mask flag"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Generate rough skull image (not as clean as betsurf)", 
+            "value-key": "[APPROX_SKULL_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "approx_skull_flag", 
+            "name": "Approximate skull flag"
+        }, 
+        {
+            "command-line-flag": "-n", 
+            "description": "Don't generate segmented brain image output", 
+            "value-key": "[NO_SEG_OUTPUT_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "no_seg_output_flag", 
+            "name": "No segmented brain image flag"
+        }, 
+        {
+            "command-line-flag": "-e", 
+            "description": "Generate brain surface as mesh in .vtk format", 
+            "value-key": "[VTK_VIEW_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "vtk_mesh", 
+            "name": "VTK format brain surface mesh flag"
+        }, 
+        {
+            "command-line-flag": "-r", 
+            "description": "head radius (mm not voxels); initial surface sphere is set to half of this", 
+            "value-key": "[HEAD_RADIUS]", 
+            "type": "Number", 
+            "optional": true, 
+            "id": "head_radius", 
+            "name": "Head Radius"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Apply thresholding to segmented brain image and mask", 
+            "value-key": "[THRESHOLDING_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "thresholding_flag", 
+            "name": "Threshold segmented image flag"
+        }, 
+        {
+            "command-line-flag": "-R", 
+            "description": "More robust brain center estimation, by iterating BET with a changing center-of-gravity.", 
+            "value-key": "[ROBUST_ITERS_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "robust_iters_flag", 
+            "name": "Robust iterations flag"
+        }, 
+        {
+            "command-line-flag": "-S", 
+            "description": "This attempts to cleanup residual eye and optic nerve voxels which bet2 can sometimes leave behind. This can be useful when running SIENA or SIENAX, for example. Various stages involving standard-space masking, morphpological operations and thresholdings are combined to produce a result which can often give better results than just running bet2.", 
+            "value-key": "[RES_OPTIC_CLEANUP_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "residual_optic_cleanup_flag", 
+            "name": "Residual optic cleanup flag"
+        }, 
+        {
+            "command-line-flag": "-B", 
+            "description": "This attempts to reduce image bias, and residual neck voxels. This can be useful when running SIENA or SIENAX, for example. Various stages involving FAST segmentation-based bias field removal and standard-space masking are combined to produce a result which can often give better results than just running bet2.", 
+            "value-key": "[REDUCE_BIAS_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "reduce_bias_flag", 
+            "name": "Bias reduction flag"
+        }, 
+        {
+            "command-line-flag": "-Z", 
+            "description": "This can improve the brain extraction if only a few slices are present in the data (i.e., a small field of view in the Z direction). This is achieved by padding the end slices in both directions, copying the end slices several times, running bet2 and then removing the added slices.", 
+            "value-key": "[SLICE_PADDING_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "slice_padding_flag", 
+            "name": "Slice padding flag"
+        }, 
+        {
+            "command-line-flag": "-F", 
+            "description": "This option uses bet2 to determine a brain mask on the basis of the first volume in a 4D data set, and applies this to the whole data set. This is principally intended for use on FMRI data, for example to remove eyeballs. Because it is normally important (in this application) that masking be liberal (ie that there be little risk of cutting out valid brain voxels) the -f threshold is reduced to 0.3, and also the brain mask is \"dilated\" slightly before being used.", 
+            "value-key": "[MASK_WHOLE_SET_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "whole_set_mask_flag", 
+            "name": "Mask-whole-set flag"
+        }, 
+        {
+            "command-line-flag": "-A", 
+            "description": "This runs both bet2 and betsurf programs in order to get the additional skull and scalp surfaces created by betsurf. This involves registering to standard space in order to allow betsurf to find the standard space masks it needs.", 
+            "value-key": "[ADD_SURFACES_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "additional_surfaces_flag", 
+            "name": "Additional surfaces flag"
+        }, 
+        {
+            "command-line-flag": "-A2", 
+            "description": "This is the same as -A except that a T2 image is also input, to further improve the estimated skull and scalp surfaces. As well as carrying out the standard space registration this also registers the T2 to the T1 input image.", 
+            "value-key": "[ADD_SURFACES_T2]", 
+            "type": "File", 
+            "optional": true, 
+            "id": "additional_surfaces_t2", 
+            "name": "Additional surfaces with T2"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "Switch on diagnostic messages", 
+            "value-key": "[VERBOSE_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "verbose_flag", 
+            "name": "Verbose Flag"
+        }, 
+        {
+            "command-line-flag": "-d", 
+            "description": "Don't delete temporary intermediate images", 
+            "value-key": "[DEBUG_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "debug_flag", 
+            "name": "Debug Flag"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "groups": [
+        {
+            "description": "Specify parameters that alter the default BET functionality", 
+            "id": "optional_params_group", 
+            "members": [
+                "fractional_intensity", 
+                "vg_fractional_intensity", 
+                "center_of_gravity", 
+                "overlay_flag", 
+                "binary_mask_flag", 
+                "approx_skull_flag", 
+                "no_seg_output_flag", 
+                "vtk_mesh", 
+                "head_radius", 
+                "thresholding_flag"
+            ], 
+            "name": "Main Program Parameters"
+        }, 
+        {
+            "description": "Mutually exclusive options that specify variations on how BET should be run.", 
+            "mutually-exclusive": true, 
+            "id": "variational_params_group", 
+            "members": [
+                "robust_iters_flag", 
+                "residual_optic_cleanup_flag", 
+                "reduce_bias_flag", 
+                "slice_padding_flag", 
+                "whole_set_mask_flag", 
+                "additional_surfaces_flag", 
+                "additional_surfaces_t2"
+            ], 
+            "name": "Variations on Default Functionality"
+        }, 
+        {
+            "description": "Optional miscellaneous parameters when running BET", 
+            "id": "miscellaneous_params_group", 
+            "members": [
+                "verbose_flag", 
+                "debug_flag"
+            ], 
+            "name": "Miscellaneous Parameters"
+        }
+    ], 
+    "output-files": [
+        {
+            "path-template": "[MASK].nii.gz", 
+            "description": "Main default mask output of BET", 
+            "optional": true, 
+            "id": "outfile", 
+            "name": "Output mask file"
+        }, 
+        {
+            "path-template": "[MASK]_mask.nii.gz", 
+            "description": "Binary mask file (from -m option)", 
+            "optional": true, 
+            "id": "binary_mask", 
+            "name": "Output binary mask file"
+        }, 
+        {
+            "path-template": "[MASK]_overlay.nii.gz", 
+            "description": "Overlaid brain surface onto original image", 
+            "optional": true, 
+            "id": "overlay_file", 
+            "name": "Surface overlay file"
+        }, 
+        {
+            "path-template": "[MASK]_skull.nii.gz", 
+            "description": "Approximate skull image file", 
+            "optional": true, 
+            "id": "approx_skull_img", 
+            "name": "Approximate skull file"
+        }, 
+        {
+            "path-template": "[MASK]_mesh.vtk", 
+            "description": "Mesh in VTK format", 
+            "optional": true, 
+            "id": "output_vtk_mesh", 
+            "name": "VTK mesh"
+        }, 
+        {
+            "path-template": "[MASK]_skull_mask.nii.gz", 
+            "description": "Output mask for skull image", 
+            "optional": true, 
+            "id": "skull_mask", 
+            "name": "Skull mask image"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mask.nii.gz", 
+            "description": "The in-skull mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_mask", 
+            "name": "Output in-skull mask file"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mesh.nii.gz", 
+            "description": "The in-skull mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_mesh", 
+            "name": "Output in-skull mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_inskull_mesh.off", 
+            "description": "The in-skull mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_inskull_off", 
+            "name": "Output in-skull mesh off file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mask.nii.gz", 
+            "description": "The out-skin mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_mask", 
+            "name": "Output out-skin mask file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mesh.nii.gz", 
+            "description": "The out-skin mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_mesh", 
+            "name": "Output out-skin mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_outskin_mesh.off", 
+            "description": "The out-skin mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskin_off", 
+            "name": "Output out-skin mesh off file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mask.nii.gz", 
+            "description": "The out-skull mask file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_mask", 
+            "name": "Output out-skull mask file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mesh.nii.gz", 
+            "description": "The out-skull mesh file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_mesh", 
+            "name": "Output out-skull mesh file"
+        }, 
+        {
+            "path-template": "[MASK]_outskull_mesh.off", 
+            "description": "The out-skull mesh .off file from betsurf (from -A or -A2)", 
+            "optional": true, 
+            "id": "out_outskull_off", 
+            "name": "Output out-skull mesh off file"
+        }
+    ], 
+    "description": "Automated brain extraction tool for FSL"
 }

--- a/cbrain_task_descriptors/fsl_fast.json
+++ b/cbrain_task_descriptors/fsl_fast.json
@@ -1,216 +1,246 @@
 {
-	"name" : "fsl_fast",
-	"tool-version" : "5.0.0",
-	"description" : "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time.",
-	"command-line" : "fast [NUM_CLASSES] [LOOP_ITERS] [BF_SMOOTHING] [IMG_TYPE] [INIT_SEG_SMOOTHNESS] [BINARY_SEGMENTS] [PRIOR_INIT] [NO_PVE] [BIAS_FIELD] [BIAS_CORR_IMG] [NO_BIAS_RM] [OUTPUT_BASENAME] [PRIORS_THROUGHOUT] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [NUM_MAIN_LOOP_ITERS] [HYPER_SEG_SMOOTHNESS] [VERBOSE] [MANUAL_INTENSITIES_FILE] [OUTPUT_PROB_MAPS] [IN_FILES]; mkdir [OUTPUT_DIRECTORY]; mv [OUTPUT_DIRECTORY]_* [OUTPUT_DIRECTORY]",
-	"schema-version" : "0.4",
-	"inputs" : [{
-		"id" : "num_classes",
-		"name" : "Number of tissue-type classes",
-		"type" : "Number",
-		"description" : "Number of tissue-type classes; default = 3.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-n",
-		"value-key" : "[NUM_CLASSES]",
-		"minimum" : 1,
-		"integer" : true
-	}, {
-		"id" : "loop_iters",
-		"name" : "Bias removal main-loop iterations",
-		"type" : "Number",
-		"description" : "Number of main-loop iterations during bias-field removal (default = 4).",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-I",
-		"value-key" : "[LOOP_ITERS]",
-		"minimum" : 1,
-		"integer" : true
-	}, {
-		"id" : "bf_smoothing",
-		"name" : "Bias field smoothing",
-		"type" : "Number",
-		"description" : "Bias field smoothing extent (FWHM) in mm (default = 20).",
-		"list" : false,
-		"command-line-flag" : "-l",
-		"optional" : true,
-		"value-key" : "[BF_SMOOTHING]",
-		"minimum" : 0
-	}, {
-		"id" : "img_type",
-		"name" : "Image type",
-		"type" : "String",
-		"description" : "Type of image: 1 = T1, 2 = T2, 3 = PD. Default = T1.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-t",
-		"value-choices" : ["1","2","3"],
-		"value-key" : "[IMG_TYPE]"
-	}, {
-		"id" : "init_seg_smoothness",
-		"name" : "Initial segmentation smoothness",
-		"type" : "Number",
-		"description" : "Initial segmentation spatial smoothness (during bias field estimation); default = 0.02.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-f",
-		"value-key" : "[INIT_SEG_SMOOTHNESS]"
-	}, {
-		"id" : "binary_segments",
-		"name" : "Binary images",
-		"type" : "Flag",
-		"description" : "Outputs a separate binary image for each tissue type",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-g",
-		"value-key" : "[BINARY_SEGMENTS]"
-	}, {
-		"id" : "prior_init",
-		"name" : "Prior Initialization",
-		"type" : "File",
-		"description" : "Initialize using priors. A FLIRT transform must be provided (e.g. std2input.mat)",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-a",
-		"value-key" : "[PRIOR_INIT]"
-	}, {
-		"id" : "no_pve",
-		"name" : "No PVE",
-		"type" : "Flag",
-		"description" : "Turn off PVE (partial volume estimation).",
-		"list" : false,
-		"command-line-flag" : "--nopve",
-		"optional" : true,
-		"value-key" : "[NO_PVE]"
-	}, {
-		"id" : "bias_field",
-		"name" : "Bias field",
-		"type" : "Flag",
-		"description" : "Output estimated bias field.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-b",
-		"value-key" : "[BIAS_FIELD]"
-	}, {
-		"id" : "bias_corr_img",
-		"name" : "Bias corrected image",
-		"type" : "Flag",
-		"description" : "Output bias corrected image.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-B",
-		"value-key" : "[BIAS_CORR_IMG]"
-	}, {
-		"id" : "no_bias_rm",
-		"name" : "No bias removal",
-		"type" : "Flag",
-		"description" : "Does not remove the bias field.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-N",
-		"value-key" : "[NO_BIAS_RM]"
-	}, {
-		"id" : "output_basename",
-		"name" : "Output basename",
-		"type" : "String",
-		"description" : "The basename of the output files.",
-		"optional" : false,
-		"list" : false,
-		"command-line-flag" : "-o",
-		"default-value" : "fast",
-		"value-key" : "[OUTPUT_BASENAME]"
-	}, {
-		"id" : "priors_throughout",
-		"name" : "Use priors throughout",
-		"type" : "Flag",
-		"description" : "Use priors throughout the process",
-		"optional" : true,
-		"list" : false,
-		"requires-inputs" : ["prior_init"],
-		"command-line-flag" : "-P",
-		"value-key" : "[PRIORS_THROUGHOUT]"
-	}, {
-		"id" : "seg_init_iters",
-		"name" : "Segmentation initialization iterations",
-		"type" : "Number",
-		"integer" : true,
-		"minimum" : 1,
-		"description" : "Number of segmentation-initialisation iterations; default = 15.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-W",
-		"value-key" : "[SEG_INIT_ITERS]"
-	}, {
-		"id" : "mixel_smoothness",
-		"name" : "Mixeltype Smoothness",
-		"type" : "Number",
-		"description" : "Spatial smoothness of mixeltype; default = 0.3.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-R",
-		"value-key" : "[MIXEL_SMOOTHNESS]"
-	}, {
-		"id" : "num_main_loop_iters",
-		"name" : "Main loop iterations",
-		"type" : "Number",
-		"integer" : true,
-		"minimum" : 1,
-		"description" : "Number of main-loop iterations after bias-field removal (default = 4).",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-O",
-		"value-key" : "[NUM_MAIN_LOOP_ITERS]"
-	}, {
-		"id" : "hyper_seg_smoothness",
-		"name" : "Segmentation spatial smoothness",
-		"type" : "Number",
-		"description" : "Segmentation spatial smoothness; default = 0.1.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-H",
-		"value-key" : "[HYPER_SEG_SMOOTHNESS]"
-	}, {
-		"id" : "verbose",
-		"name" : "Verbose",
-		"type" : "Flag",
-		"description" : "Verbose mode",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-v",
-		"value-key" : "[VERBOSE]"
-	}, {
-		"id" : "manual_intensities_file",
-		"name" : "Manual segmentation",
-		"type" : "File",
-		"description" : "Filename containing the intensities",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-s",
-		"value-key" : "[MANUAL_INTENSITIES_FILE]"
-	}, {
-		"id" : "output_prob_maps",
-		"name" : "Single probability maps",
-		"type" : "Flag",
-		"description" : "Output individual probability maps",
-		"list" : false,
-		"command-line-flag" : "-p",
-		"optional" : true,
-		"value-key" : "[OUTPUT_PROB_MAPS]"
-	}, {
-		"id" : "in_files",
-		"name" : "Input file",
-		"type" : "File",
-		"description" : "Input file",
-		"optional" : false,
-		"list" : false,
-		"value-key" : "[IN_FILES]"
-	}],
-	"output-files" :  [{
-		"id" : "output_dir",
-		"name" : "Output Directory",
-		"description" : "Output files from FSL FAST",
-		"path-template" : "[OUTPUT_BASENAME]",
-		"value-key" : "[OUTPUT_DIRECTORY]",
-		"optional" : false
-	}]
+    "tool-version": "5.0.0", 
+    "name": "fsl_fast", 
+    "command-line": "fast [NUM_CLASSES] [LOOP_ITERS] [BF_SMOOTHING] [IMG_TYPE] [INIT_SEG_SMOOTHNESS] [BINARY_SEGMENTS] [PRIOR_INIT] [NO_PVE] [BIAS_FIELD] [BIAS_CORR_IMG] [NO_BIAS_RM] [OUTPUT_BASENAME] [PRIORS_THROUGHOUT] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [NUM_MAIN_LOOP_ITERS] [HYPER_SEG_SMOOTHNESS] [VERBOSE] [MANUAL_INTENSITIES_FILE] [OUTPUT_PROB_MAPS] [IN_FILES]; mkdir [OUTPUT_DIRECTORY]; mv [OUTPUT_DIRECTORY]_* [OUTPUT_DIRECTORY]", 
+    "inputs": [
+        {
+            "command-line-flag": "-n", 
+            "description": "Number of tissue-type classes; default = 3.", 
+            "value-key": "[NUM_CLASSES]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "optional": true, 
+            "id": "num_classes", 
+            "name": "Number of tissue-type classes"
+        }, 
+        {
+            "command-line-flag": "-I", 
+            "description": "Number of main-loop iterations during bias-field removal (default = 4).", 
+            "value-key": "[LOOP_ITERS]", 
+            "type": "Number", 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "optional": true, 
+            "id": "loop_iters", 
+            "name": "Bias removal main-loop iterations"
+        }, 
+        {
+            "command-line-flag": "-l", 
+            "description": "Bias field smoothing extent (FWHM) in mm (default = 20).", 
+            "value-key": "[BF_SMOOTHING]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 0, 
+            "type": "Number", 
+            "id": "bf_smoothing", 
+            "name": "Bias field smoothing"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Type of image: 1 = T1, 2 = T2, 3 = PD. Default = T1.", 
+            "value-key": "[IMG_TYPE]", 
+            "type": "String", 
+            "list": false, 
+            "value-choices": [
+                "1", 
+                "2", 
+                "3"
+            ], 
+            "optional": true, 
+            "id": "img_type", 
+            "name": "Image type"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "Initial segmentation spatial smoothness (during bias field estimation); default = 0.02.", 
+            "value-key": "[INIT_SEG_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "init_seg_smoothness", 
+            "name": "Initial segmentation smoothness"
+        }, 
+        {
+            "command-line-flag": "-g", 
+            "description": "Outputs a separate binary image for each tissue type", 
+            "value-key": "[BINARY_SEGMENTS]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "binary_segments", 
+            "name": "Binary images"
+        }, 
+        {
+            "command-line-flag": "-a", 
+            "description": "Initialize using priors. A FLIRT transform must be provided (e.g. std2input.mat)", 
+            "value-key": "[PRIOR_INIT]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "prior_init", 
+            "name": "Prior Initialization"
+        }, 
+        {
+            "command-line-flag": "--nopve", 
+            "description": "Turn off PVE (partial volume estimation).", 
+            "value-key": "[NO_PVE]", 
+            "optional": true, 
+            "list": false, 
+            "type": "Flag", 
+            "id": "no_pve", 
+            "name": "No PVE"
+        }, 
+        {
+            "command-line-flag": "-b", 
+            "description": "Output estimated bias field.", 
+            "value-key": "[BIAS_FIELD]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "bias_field", 
+            "name": "Bias field"
+        }, 
+        {
+            "command-line-flag": "-B", 
+            "description": "Output bias corrected image.", 
+            "value-key": "[BIAS_CORR_IMG]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "bias_corr_img", 
+            "name": "Bias corrected image"
+        }, 
+        {
+            "command-line-flag": "-N", 
+            "description": "Does not remove the bias field.", 
+            "value-key": "[NO_BIAS_RM]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "no_bias_rm", 
+            "name": "No bias removal"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "The basename of the output files.", 
+            "default-value": "fast", 
+            "value-key": "[OUTPUT_BASENAME]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "output_basename", 
+            "name": "Output basename"
+        }, 
+        {
+            "command-line-flag": "-P", 
+            "description": "Use priors throughout the process", 
+            "value-key": "[PRIORS_THROUGHOUT]", 
+            "type": "Flag", 
+            "list": false, 
+            "requires-inputs": [
+                "prior_init"
+            ], 
+            "optional": true, 
+            "id": "priors_throughout", 
+            "name": "Use priors throughout"
+        }, 
+        {
+            "command-line-flag": "-W", 
+            "description": "Number of segmentation-initialisation iterations; default = 15.", 
+            "value-key": "[SEG_INIT_ITERS]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "seg_init_iters", 
+            "name": "Segmentation initialization iterations"
+        }, 
+        {
+            "command-line-flag": "-R", 
+            "description": "Spatial smoothness of mixeltype; default = 0.3.", 
+            "value-key": "[MIXEL_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "mixel_smoothness", 
+            "name": "Mixeltype Smoothness"
+        }, 
+        {
+            "command-line-flag": "-O", 
+            "description": "Number of main-loop iterations after bias-field removal (default = 4).", 
+            "value-key": "[NUM_MAIN_LOOP_ITERS]", 
+            "optional": true, 
+            "list": false, 
+            "minimum": 1, 
+            "integer": true, 
+            "type": "Number", 
+            "id": "num_main_loop_iters", 
+            "name": "Main loop iterations"
+        }, 
+        {
+            "command-line-flag": "-H", 
+            "description": "Segmentation spatial smoothness; default = 0.1.", 
+            "value-key": "[HYPER_SEG_SMOOTHNESS]", 
+            "type": "Number", 
+            "list": false, 
+            "optional": true, 
+            "id": "hyper_seg_smoothness", 
+            "name": "Segmentation spatial smoothness"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "Verbose mode", 
+            "value-key": "[VERBOSE]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "verbose", 
+            "name": "Verbose"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Filename containing the intensities", 
+            "value-key": "[MANUAL_INTENSITIES_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "manual_intensities_file", 
+            "name": "Manual segmentation"
+        }, 
+        {
+            "command-line-flag": "-p", 
+            "description": "Output individual probability maps", 
+            "value-key": "[OUTPUT_PROB_MAPS]", 
+            "optional": true, 
+            "list": false, 
+            "type": "Flag", 
+            "id": "output_prob_maps", 
+            "name": "Single probability maps"
+        }, 
+        {
+            "description": "Input file", 
+            "value-key": "[IN_FILES]", 
+            "type": "File", 
+            "list": false, 
+            "optional": false, 
+            "id": "in_files", 
+            "name": "Input file"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "Output files from FSL FAST", 
+            "value-key": "[OUTPUT_DIRECTORY]", 
+            "id": "output_dir", 
+            "optional": false, 
+            "path-template": "[OUTPUT_BASENAME]", 
+            "name": "Output Directory"
+        }
+    ], 
+    "description": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time."
 }

--- a/cbrain_task_descriptors/fsl_first.json
+++ b/cbrain_task_descriptors/fsl_first.json
@@ -1,89 +1,100 @@
 {
-	"name" : "fsl_first",
-	"tool-version" : "5.0.0",
-	"description" : "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures.",
-	"command-line" : "run_first_all [METHOD] [BRAIN_EXTRACTED] [SPECIFIED_STRUCTURE] [AFFINE] [THREE_STAGE] [VERBOSE] [INPUT_FILE] [OUTPUT_NAME]",
-	"schema-version" : "0.4",
-	"inputs" : [{
-		"id" : "method",
-		"name" : "Method",
-		"type" : "String",
-		"description" : "Method must be one of 'auto' (default), 'fast', 'none', or it can be a numerical threshold value. This specifies the boundary correction method. Auto chooses different options for different structures using the settings that were found to be empirically optimal for each structure. Other options use: fast (using FAST-based, mixture-model, tissue-type classification) or threshold (thresholds a simple single-Gaussian intensity model).",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-m",
-		"value-key" : "[METHOD]"
-	}, {
-		"id" : "input_file",
-		"name" : "Input file",
-		"type" : "File",
-		"description" : "Input image file (e.g. img.nii.gz).",
-		"optional" : false,
-		"list" : false,
-		"command-line-flag" : "-i",
-		"value-key" : "[INPUT_FILE]"
-	}, {
-		"id" : "output_name",
-		"name" : "Output name",
-		"type" : "String",
-		"description" : "Output name to use for first",
-		"optional" : false,
-		"list" : false,
-		"default-value" : "first_output",
-		"command-line-flag" : "-o",
-		"value-key" : "[OUTPUT_NAME]"
-	}, {
-		"id" : "brain_extracted",
-		"name" : "Brain extracted",
-		"type" : "Flag",
-		"description" : "Whether the input is already brain extracted.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-b",
-		"value-key" : "[BRAIN_EXTRACTED]"
-	}, {
-		"id" : "specified_structure",
-		"name" : "Specify structure",
-		"type" : "String",
-		"description" : "Run only on one specified structure (e.g. L_Hipp) or a comma-separated list (no spaces). Choose from: 'L_Hipp', 'R_Hipp', 'L_Accu', 'R_Accu', 'L_Amyg', 'R_Amyg', 'L_Caud', 'R_Caud', 'L_Pall', 'R_Pall', 'L_Puta', 'R_Puta', 'L_Thal', 'R_Thal', 'BrStem'.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-s",
-		"value-key" : "[SPECIFIED_STRUCTURE]"
-	}, {
-		"id" : "affine",
-		"name" : "Use Affine Matrix",
-		"type" : "File",
-		"description" : "Use affine matrix (i.e. do not re-run registration).",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-a",
-		"value-key" : "[AFFINE]"
-	}, {
-		"id" : "three_stage",
-		"name" : "Three stage registration",
-		"type" : "Flag",
-		"description" : "Use 3-stage affine registration. Only currently implemented for the hippocampus.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-3",
-		"value-key" : "[THREE_STAGE]"
-	}, {
-		"id" : "verbose",
-		"name" : "Verbose",
-		"type" : "Flag",
-		"description" : "Verbose output.",
-		"optional" : true,
-		"list" : false,
-		"command-line-flag" : "-v",
-		"value-key" : "[VERBOSE]"
-	}],
-	"output-files" :  [{
-		"id" : "output_directory",
-		"name" : "First Output Directory",
-		"description" : "Collection of files from first",
-		"path-template" : "[OUTPUT_NAME]*",
-		"list" : true,
-		"optional" : false
-	}]
+    "tool-version": "5.0.0", 
+    "name": "fsl_first", 
+    "command-line": "run_first_all [METHOD] [BRAIN_EXTRACTED] [SPECIFIED_STRUCTURE] [AFFINE] [THREE_STAGE] [VERBOSE] [INPUT_FILE] [OUTPUT_NAME]", 
+    "inputs": [
+        {
+            "command-line-flag": "-m", 
+            "description": "Method must be one of 'auto' (default), 'fast', 'none', or it can be a numerical threshold value. This specifies the boundary correction method. Auto chooses different options for different structures using the settings that were found to be empirically optimal for each structure. Other options use: fast (using FAST-based, mixture-model, tissue-type classification) or threshold (thresholds a simple single-Gaussian intensity model).", 
+            "value-key": "[METHOD]", 
+            "type": "String", 
+            "list": false, 
+            "optional": true, 
+            "id": "method", 
+            "name": "Method"
+        }, 
+        {
+            "command-line-flag": "-i", 
+            "description": "Input image file (e.g. img.nii.gz).", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "list": false, 
+            "optional": false, 
+            "id": "input_file", 
+            "name": "Input file"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "Output name to use for first", 
+            "default-value": "first_output", 
+            "value-key": "[OUTPUT_NAME]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "output_name", 
+            "name": "Output name"
+        }, 
+        {
+            "command-line-flag": "-b", 
+            "description": "Whether the input is already brain extracted.", 
+            "value-key": "[BRAIN_EXTRACTED]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "brain_extracted", 
+            "name": "Brain extracted"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Run only on one specified structure (e.g. L_Hipp) or a comma-separated list (no spaces). Choose from: 'L_Hipp', 'R_Hipp', 'L_Accu', 'R_Accu', 'L_Amyg', 'R_Amyg', 'L_Caud', 'R_Caud', 'L_Pall', 'R_Pall', 'L_Puta', 'R_Puta', 'L_Thal', 'R_Thal', 'BrStem'.", 
+            "value-key": "[SPECIFIED_STRUCTURE]", 
+            "type": "String", 
+            "list": false, 
+            "optional": true, 
+            "id": "specified_structure", 
+            "name": "Specify structure"
+        }, 
+        {
+            "command-line-flag": "-a", 
+            "description": "Use affine matrix (i.e. do not re-run registration).", 
+            "value-key": "[AFFINE]", 
+            "type": "File", 
+            "list": false, 
+            "optional": true, 
+            "id": "affine", 
+            "name": "Use Affine Matrix"
+        }, 
+        {
+            "command-line-flag": "-3", 
+            "description": "Use 3-stage affine registration. Only currently implemented for the hippocampus.", 
+            "value-key": "[THREE_STAGE]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "three_stage", 
+            "name": "Three stage registration"
+        }, 
+        {
+            "command-line-flag": "-v", 
+            "description": "Verbose output.", 
+            "value-key": "[VERBOSE]", 
+            "type": "Flag", 
+            "list": false, 
+            "optional": true, 
+            "id": "verbose", 
+            "name": "Verbose"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "Collection of files from first", 
+            "list": true, 
+            "id": "output_directory", 
+            "optional": false, 
+            "path-template": "[OUTPUT_NAME]*", 
+            "name": "First Output Directory"
+        }
+    ], 
+    "description": "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures."
 }

--- a/cbrain_task_descriptors/fsl_probtrackx2.json
+++ b/cbrain_task_descriptors/fsl_probtrackx2.json
@@ -1,119 +1,137 @@
 {
-  "name"         : "fsl_probtrackx2",
-  "tool-version" : "1.0.0",
-  "description"  : "probabilistic tracking with crossing fibres",
-  "command-line" : "cp -rL [INPUT_DIR] [OUTPUT_DIR]; probtrackx2 -s [OUTPUT_DIR]/[BASENAME] -m [OUTPUT_DIR]/[MASKNAME] -x [SEEDFILE] --dir=[OUTPUT_DIR]/[FINALDIR] [FORCEDIR] [OPD] [PD] [OS2T] --targetmasks=[TARGETMASKS] --xfm=[OUTPUT_DIR]/[XFM] --invxfm=[OUTPUT_DIR]/[INVXFM]",
-  "container-image" : {
-    "type" : "docker",
-    "image" : "mcin/docker-fsl:latest",
-    "index" : "http://index.docker.io"
-  },
-  "schema-version" : "0.4",
-  "walltime-estimate" : 331200,
-  "inputs" : [{
-    "id"          : "inputdir",
-    "name"        : "Input Directory",
-    "type"        : "File",
-    "description" : "A bedpostX directory",
-    "optional" : false,
-    "value-key" : "[INPUT_DIR]"
-  },{
-    "id"          : "basename",
-    "name"        : "Base name",
-    "type"        : "String",
-    "description" : "Basename for samples files - e.g. 'merged'",
-    "optional" : false,
-    "value-key" : "[BASENAME]"
-  },{
-    "id"          : "maskname",
-    "name"        : "Mask name",
-    "type"        : "String",
-    "description" : "Bet binary mask file in diffusion space",
-    "optional" : false,
-    "value-key" : "[MASKNAME]"
-  },{
-    "id"          : "seedfile",
-    "name"        : "Seed file",
-    "type"        : "File",
-    "description" : "Seed volume or list (ascii text file) of volumes and/or surfaces",
-    "optional" : false,
-    "value-key" : "[SEEDFILE]"
-  },{
-    "id"          : "finaldir",
-    "name"        : "Directory to put the final volumes in",
-    "type"        : "String",
-    "description" : "Directory to put the final volumes in - code makes this directory - default='logdir'",
-    "optional" : false,
-    "value-key" : "[FINALDIR]"
-  },{
-    "id"          : "forcedir",
-    "name"        : "Use the actual directory name given",
-    "type"        : "Flag",
-    "default-value" : true,
-    "description" : "Use the actual directory name given - i.e. don't add + to make a new directory",
-    "command-line-flag" : "--forcedir",
-    "value-key" : "[FORCEDIR]"
-  },{
-    "id"          : "outputpath",
-    "name"        : "Output path",
-    "type"        : "Flag",
-    "description" : "Output path distribution",
-    "default-value" : true,
-    "command-line-flag" : "--opd",
-    "value-key" : "[OPD]"
-  },{
-    "id"          : "pathdistribution",
-    "name"        : "Correct path distribution",
-    "type"        : "Flag",
-    "default-value" : true,
-    "description" : "Correct path distribution for the length of the pathways",
-    "command-line-flag" : "--pd",
-    "value-key" : "[PD]"
-  },{
-    "id"          : "outseeds",
-    "name"        : "Output seeds",
-    "type"        : "Flag",
-    "description" : "Output seeds to targets",
-    "default-value" : true,
-    "command-line-flag" : "--os2t",
-    "value-key" : "[OS2T]"
-  },{
-    "id"          : "targetmasks",
-    "name"        : "File containing a list of target masks",
-    "type"        : "File",
-    "description" : "File containing a list of target masks - for seeds_to_targets classification",
-    "optional" : false,
-    "value-key" : "[TARGETMASKS]"
-  },{
-    "id"          : "xfm",
-    "name"        : "Transform taking seed space to DTI space",
-    "type"        : "String",
-    "description" : "Transform taking seed space to DTI space (either FLIRT matrix or FNIRT warpfield) - default is identity",
-    "optional" : false,
-    "value-key" : "[XFM]"
-  },{
-    "id"          : "infxfm",
-    "name"        : "Transform taking DTI space to seed space",
-    "type"        : "String",
-    "description" : "Transform taking DTI space to seed space (compulsory when using a warpfield for seeds_to_dti)",
-    "optional" : false,
-    "value-key" : "[INVXFM]"
-  },{
-    "id" : "outdir",
-    "name" : "Output directory",
-    "type" : "String",
-    "description" : "Output directory name.",
-    "optional" : false,
-    "list" : false,
-    "value-key" : "[OUTPUT_DIR]",
-    "default-value" : "probtrackx2_output"
-  }],
-  "output-files" :  [{
-    "id" : "folder_out",
-    "name" : "Output folder",
-    "description" : "A folder containing the output result.",
-    "path-template" : "[OUTPUT_DIR]",
-    "list" : false,
-    "optional" : false
-  }]
+    "tool-version": "1.0.0", 
+    "name": "fsl_probtrackx2", 
+    "command-line": "cp -rL [INPUT_DIR] [OUTPUT_DIR]; probtrackx2 -s [OUTPUT_DIR]/[BASENAME] -m [OUTPUT_DIR]/[MASKNAME] -x [SEEDFILE] --dir=[OUTPUT_DIR]/[FINALDIR] [FORCEDIR] [OPD] [PD] [OS2T] --targetmasks=[TARGETMASKS] --xfm=[OUTPUT_DIR]/[XFM] --invxfm=[OUTPUT_DIR]/[INVXFM]", 
+    "inputs": [
+        {
+            "description": "A bedpostX directory", 
+            "value-key": "[INPUT_DIR]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "inputdir", 
+            "name": "Input Directory"
+        }, 
+        {
+            "description": "Basename for samples files - e.g. 'merged'", 
+            "value-key": "[BASENAME]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "basename", 
+            "name": "Base name"
+        }, 
+        {
+            "description": "Bet binary mask file in diffusion space", 
+            "value-key": "[MASKNAME]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "maskname", 
+            "name": "Mask name"
+        }, 
+        {
+            "description": "Seed volume or list (ascii text file) of volumes and/or surfaces", 
+            "value-key": "[SEEDFILE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "seedfile", 
+            "name": "Seed file"
+        }, 
+        {
+            "description": "Directory to put the final volumes in - code makes this directory - default='logdir'", 
+            "value-key": "[FINALDIR]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "finaldir", 
+            "name": "Directory to put the final volumes in"
+        }, 
+        {
+            "command-line-flag": "--forcedir", 
+            "description": "Use the actual directory name given - i.e. don't add + to make a new directory", 
+            "default-value": true, 
+            "value-key": "[FORCEDIR]", 
+            "type": "Flag", 
+            "id": "forcedir", 
+            "name": "Use the actual directory name given"
+        }, 
+        {
+            "command-line-flag": "--opd", 
+            "description": "Output path distribution", 
+            "default-value": true, 
+            "value-key": "[OPD]", 
+            "type": "Flag", 
+            "id": "outputpath", 
+            "name": "Output path"
+        }, 
+        {
+            "command-line-flag": "--pd", 
+            "description": "Correct path distribution for the length of the pathways", 
+            "default-value": true, 
+            "value-key": "[PD]", 
+            "type": "Flag", 
+            "id": "pathdistribution", 
+            "name": "Correct path distribution"
+        }, 
+        {
+            "command-line-flag": "--os2t", 
+            "description": "Output seeds to targets", 
+            "default-value": true, 
+            "value-key": "[OS2T]", 
+            "type": "Flag", 
+            "id": "outseeds", 
+            "name": "Output seeds"
+        }, 
+        {
+            "description": "File containing a list of target masks - for seeds_to_targets classification", 
+            "value-key": "[TARGETMASKS]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "targetmasks", 
+            "name": "File containing a list of target masks"
+        }, 
+        {
+            "description": "Transform taking seed space to DTI space (either FLIRT matrix or FNIRT warpfield) - default is identity", 
+            "value-key": "[XFM]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "xfm", 
+            "name": "Transform taking seed space to DTI space"
+        }, 
+        {
+            "description": "Transform taking DTI space to seed space (compulsory when using a warpfield for seeds_to_dti)", 
+            "value-key": "[INVXFM]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "infxfm", 
+            "name": "Transform taking DTI space to seed space"
+        }, 
+        {
+            "description": "Output directory name.", 
+            "default-value": "probtrackx2_output", 
+            "value-key": "[OUTPUT_DIR]", 
+            "type": "String", 
+            "list": false, 
+            "optional": false, 
+            "id": "outdir", 
+            "name": "Output directory"
+        }
+    ], 
+    "container-image": {
+        "index": "index.docker.io", 
+        "image": "mcin/docker-fsl:latest", 
+        "type": "docker"
+    }, 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "description": "A folder containing the output result.", 
+            "list": false, 
+            "id": "folder_out", 
+            "optional": false, 
+            "path-template": "[OUTPUT_DIR]", 
+            "name": "Output folder"
+        }
+    ], 
+    "suggested-resources": {
+        "walltime-estimate": 331200
+    }, 
+    "description": "probabilistic tracking with crossing fibres"
 }

--- a/cbrain_task_descriptors/fsl_probtrackx2.json
+++ b/cbrain_task_descriptors/fsl_probtrackx2.json
@@ -48,6 +48,7 @@
             "description": "Use the actual directory name given - i.e. don't add + to make a new directory", 
             "default-value": true, 
             "value-key": "[FORCEDIR]", 
+            "optional": true, 
             "type": "Flag", 
             "id": "forcedir", 
             "name": "Use the actual directory name given"
@@ -57,6 +58,7 @@
             "description": "Output path distribution", 
             "default-value": true, 
             "value-key": "[OPD]", 
+            "optional": true, 
             "type": "Flag", 
             "id": "outputpath", 
             "name": "Output path"
@@ -66,6 +68,7 @@
             "description": "Correct path distribution for the length of the pathways", 
             "default-value": true, 
             "value-key": "[PD]", 
+            "optional": true, 
             "type": "Flag", 
             "id": "pathdistribution", 
             "name": "Correct path distribution"
@@ -75,6 +78,7 @@
             "description": "Output seeds to targets", 
             "default-value": true, 
             "value-key": "[OS2T]", 
+            "optional": true, 
             "type": "Flag", 
             "id": "outseeds", 
             "name": "Output seeds"

--- a/cbrain_task_descriptors/fsl_sub.json
+++ b/cbrain_task_descriptors/fsl_sub.json
@@ -1,20 +1,20 @@
 {
-  "name": "fsl_sub",
-  "tool-version": "2.0",
-  "description": "A wrapper for FSL sub. Assumes that task will run on a file system shared with the submission process, that input files are already in place, and that output files will be handled by another process.",
-  "command-line": "fsl_sub /bin/bash .new-task-[SUBTASK_ID].sh",
-  "schema-version": "0.4",
-  "inputs": [
-    {
-      "id": "subtask_id",
-      "name": "Subtask ID",
-      "type": "String",
-      "description": "The ID of a subtask descriptor created by fsl_sub",
-      "value-key": "[SUBTASK_ID]",
-      "list": false,
-      "optional": false,
-      "default-value": null
-    }
-  ],
-  "output-files": []
+    "tool-version": "2.0", 
+    "name": "fsl_sub", 
+    "command-line": "fsl_sub /bin/bash .new-task-[SUBTASK_ID].sh", 
+    "inputs": [
+        {
+            "description": "The ID of a subtask descriptor created by fsl_sub", 
+            "default-value": null, 
+            "value-key": "[SUBTASK_ID]", 
+            "optional": false, 
+            "list": false, 
+            "type": "String", 
+            "id": "subtask_id", 
+            "name": "Subtask ID"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [], 
+    "description": "A wrapper for FSL sub. Assumes that task will run on a file system shared with the submission process, that input files are already in place, and that output files will be handled by another process."
 }

--- a/cbrain_task_descriptors/mincbet.json
+++ b/cbrain_task_descriptors/mincbet.json
@@ -1,139 +1,158 @@
 {
-  "name" : "MINCBet",
-  "tool-version" : "1.0.0",
-  "description" : "Automated brain extraction tool wrapper for the MINC libraries",
-  "command-line" : "mincbet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [HYPERINTENSE_THRESHOLD] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [BIC_VIEW_FLAG] [REVERSED_FLAG] [THRESHOLDING_FLAG]",
-  "schema-version" : "0.4",
-  "inputs" : [{
-    "id" : "infile",
-    "name" : "Input file",
-    "type" : "File",
-    "description" : "Input image file in mnc format",
-    "optional": false,
-    "value-key" : "[INPUT_FILE]"
-  }, {
-    "id" : "maskfile",
-    "name" : "Mask file",
-    "type" : "String",
-    "description" : "Output brain mask in mnc format",
-    "optional": false,
-    "value-key" : "[MASK]"
-  }, {
-    "id" : "fractional_intensity",
-    "name" : "Fractional intensity threshold",
-    "type" : "Number",
-    "description" : "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates",
-    "command-line-flag": "-f",
-    "optional" : true,
-    "minimum" : 0,
-    "maximum" : 1,
-    "value-key" : "[FRACTIONAL_INTENSITY]"
-  }, {
-    "id" : "vg_fractional_intensity",
-    "name" : "Vertical gradient fractional intensity threshold",
-    "type" : "Number",
-    "description" : "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top",
-    "command-line-flag": "-g",
-    "optional" : true,
-    "minimum" : -1,
-    "maximum" : 1,
-    "value-key" : "[VERTICAL_GRADIENT]"
-  }, {
-    "id" : "hyperintensity_threshold",
-    "name" : "Hyperintensity ratio threshold",
-    "type" : "Number",
-    "description" : "Ratio for hyperintense voxels (>1) (best for t1); smaller values remove more brain; default=none",
-    "command-line-flag": "-h",
-    "optional" : true,
-    "minimum" : 1,
-    "exclusive-minimum" : true,
-    "value-key" : "[HYPERINTENSE_THRESHOLD]"
-  }, {
-    "id" : "overlay_flag",
-    "name" : "Overlay flag",
-    "type" : "Flag",
-    "description" : "Generate brain surface outline overlaid onto original image",
-    "command-line-flag": "-o",
-    "optional": true,
-    "value-key" : "[OVERLAY_FLAG]"
-  }, {
-    "id" : "binary_mask_flag",
-    "name" : "Binary mask flag",
-    "type" : "Flag",
-    "description" : "Generate binary brain mask",
-    "command-line-flag": "-m",
-    "optional": true,
-    "value-key" : "[BINARY_MASK_FLAG]"
-  }, {
-    "id" : "approx_skull_flag",
-    "name" : "Approximate skull flag",
-    "type" : "Flag",
-    "description" : "Generate approximate skull image",
-    "command-line-flag": "-s",
-    "optional": true,
-    "value-key" : "[APPROX_SKULL_FLAG]"
-  }, {
-    "id" : "no_seg_output_flag",
-    "name" : "No segmented brain image flag",
-    "type" : "Flag",
-    "description" : "Don't generate segmented brain image output",
-    "command-line-flag": "-n",
-    "optional": true,
-    "value-key" : "[NO_SEG_OUTPUT_FLAG]"
-  }, {
-    "id" : "bic_view_flag",
-    "name" : "BIC brain-view format flag",
-    "type" : "Flag",
-    "description" : "Generate surface mask in BIC brain-view format",
-    "command-line-flag": "-b",
-    "optional": true,
-    "value-key" : "[BIC_VIEW_FLAG]"
-  }, {
-    "id" : "reversed_flag",
-    "name" : "Intensity reversal flag",
-    "type" : "Flag",
-    "description" : "Reversed intensities, like t2 and pd",
-    "command-line-flag": "-r",
-    "optional": true,
-    "value-key" : "[REVERSED_FLAG]"
-  }, {
-    "id" : "thresholding_flag",
-    "name" : "Threshold segmented image flag",
-    "type" : "Flag",
-    "description" : "Apply thresholding to segmented brain image and mask",
-    "command-line-flag": "-t",
-    "optional": true,
-    "value-key" : "[THRESHOLDING_FLAG]"
-  }],
-  "output-files" :  [{
-    "id" : "output_mask",
-    "name" : "Output mask file",
-    "description" : "Segmented brain mask file in mnc format",
-    "path-template" : "[MASK].mnc",
-    "optional" : true
-  }, {
-    "id" : "mask_overlay",
-    "name" : "Surface overlay file",
-    "description" : "Overlaid brain surface onto original image in mnc format",
-    "path-template" : "[MASK]_overlay.mnc",
-    "optional" : true
-  }, {
-    "id" : "approx_skull_img",
-    "name" : "Approximate skull file",
-    "description" : "Approximate skull image file in mnc format",
-    "path-template" : "[MASK]_skull.mnc",
-    "optional" : true
-  }, {
-    "id" : "binary_mask",
-    "name" : "Binary brain mask file",
-    "description" : "Binary brain mask file in mnc format",
-    "path-template" : "[MASK]_mask.mnc",
-    "optional" : true
-  }, {
-    "id" : "bic_surface_mask",
-    "name" : "BIC brain-view mask file",
-    "description" : "Surface mask in BIC brain-view format",
-    "path-template" : "[MASK].obj",
-    "optional" : true
-  }]
+    "tool-version": "1.0.0", 
+    "name": "MINCBet", 
+    "command-line": "mincbet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [HYPERINTENSE_THRESHOLD] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [BIC_VIEW_FLAG] [REVERSED_FLAG] [THRESHOLDING_FLAG]", 
+    "inputs": [
+        {
+            "description": "Input image file in mnc format", 
+            "value-key": "[INPUT_FILE]", 
+            "type": "File", 
+            "optional": false, 
+            "id": "infile", 
+            "name": "Input file"
+        }, 
+        {
+            "description": "Output brain mask in mnc format", 
+            "value-key": "[MASK]", 
+            "type": "String", 
+            "optional": false, 
+            "id": "maskfile", 
+            "name": "Mask file"
+        }, 
+        {
+            "command-line-flag": "-f", 
+            "description": "Fractional intensity threshold (0->1); default=0.5; smaller values give larger brain outline estimates", 
+            "value-key": "[FRACTIONAL_INTENSITY]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": 0, 
+            "optional": true, 
+            "id": "fractional_intensity", 
+            "name": "Fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-g", 
+            "description": "Vertical gradient in fractional intensity threshold (-1->1); default=0; positive values give larger brain outline at bottom, smaller at top", 
+            "value-key": "[VERTICAL_GRADIENT]", 
+            "type": "Number", 
+            "maximum": 1, 
+            "minimum": -1, 
+            "optional": true, 
+            "id": "vg_fractional_intensity", 
+            "name": "Vertical gradient fractional intensity threshold"
+        }, 
+        {
+            "command-line-flag": "-h", 
+            "description": "Ratio for hyperintense voxels (>1) (best for t1); smaller values remove more brain; default=none", 
+            "value-key": "[HYPERINTENSE_THRESHOLD]", 
+            "type": "Number", 
+            "minimum": 1, 
+            "exclusive-minimum": true, 
+            "optional": true, 
+            "id": "hyperintensity_threshold", 
+            "name": "Hyperintensity ratio threshold"
+        }, 
+        {
+            "command-line-flag": "-o", 
+            "description": "Generate brain surface outline overlaid onto original image", 
+            "value-key": "[OVERLAY_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "overlay_flag", 
+            "name": "Overlay flag"
+        }, 
+        {
+            "command-line-flag": "-m", 
+            "description": "Generate binary brain mask", 
+            "value-key": "[BINARY_MASK_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "binary_mask_flag", 
+            "name": "Binary mask flag"
+        }, 
+        {
+            "command-line-flag": "-s", 
+            "description": "Generate approximate skull image", 
+            "value-key": "[APPROX_SKULL_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "approx_skull_flag", 
+            "name": "Approximate skull flag"
+        }, 
+        {
+            "command-line-flag": "-n", 
+            "description": "Don't generate segmented brain image output", 
+            "value-key": "[NO_SEG_OUTPUT_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "no_seg_output_flag", 
+            "name": "No segmented brain image flag"
+        }, 
+        {
+            "command-line-flag": "-b", 
+            "description": "Generate surface mask in BIC brain-view format", 
+            "value-key": "[BIC_VIEW_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "bic_view_flag", 
+            "name": "BIC brain-view format flag"
+        }, 
+        {
+            "command-line-flag": "-r", 
+            "description": "Reversed intensities, like t2 and pd", 
+            "value-key": "[REVERSED_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "reversed_flag", 
+            "name": "Intensity reversal flag"
+        }, 
+        {
+            "command-line-flag": "-t", 
+            "description": "Apply thresholding to segmented brain image and mask", 
+            "value-key": "[THRESHOLDING_FLAG]", 
+            "type": "Flag", 
+            "optional": true, 
+            "id": "thresholding_flag", 
+            "name": "Threshold segmented image flag"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "output-files": [
+        {
+            "path-template": "[MASK].mnc", 
+            "description": "Segmented brain mask file in mnc format", 
+            "optional": true, 
+            "id": "output_mask", 
+            "name": "Output mask file"
+        }, 
+        {
+            "path-template": "[MASK]_overlay.mnc", 
+            "description": "Overlaid brain surface onto original image in mnc format", 
+            "optional": true, 
+            "id": "mask_overlay", 
+            "name": "Surface overlay file"
+        }, 
+        {
+            "path-template": "[MASK]_skull.mnc", 
+            "description": "Approximate skull image file in mnc format", 
+            "optional": true, 
+            "id": "approx_skull_img", 
+            "name": "Approximate skull file"
+        }, 
+        {
+            "path-template": "[MASK]_mask.mnc", 
+            "description": "Binary brain mask file in mnc format", 
+            "optional": true, 
+            "id": "binary_mask", 
+            "name": "Binary brain mask file"
+        }, 
+        {
+            "path-template": "[MASK].obj", 
+            "description": "Surface mask in BIC brain-view format", 
+            "optional": true, 
+            "id": "bic_surface_mask", 
+            "name": "BIC brain-view mask file"
+        }
+    ], 
+    "description": "Automated brain extraction tool wrapper for the MINC libraries"
 }


### PR DESCRIPTION
For upgrade to boutiques 0.5 in CBRAIN

@glatard can you take a look to fsl probtrackx. I had the following when doing the conversion: 

` InputError: "forcedir" should not be required`
`InputError: "outputpath" should not be required`
` InputError: "pathdistribution" should not be required`
`InputError: "outseeds" should not be required`