### PR TITLE
Add some option for CIVET 1.1.12 and bug fixes

### DIFF
--- a/cbrain_task/civet/bourreau/civet.rb
+++ b/cbrain_task/civet/bourreau/civet.rb
@@ -210,9 +210,10 @@ class CbrainTask::Civet < ClusterTask
     prefix = file0[:prefix] || "unkpref"
     dsid   = file0[:dsid]   || "unkdsid"
 
-    is_version_1_1_12         = self.tool_config.is_version("1.1.12")
-    is_at_least_version_2_0_0 = self.tool_config.is_at_least_version("2.0.0")
-    is_at_least_version_2_1_0 = self.tool_config.is_at_least_version("2.1.0")
+    is_version_1_1_12          = self.tool_config.is_version("1.1.12")
+    is_at_least_version_1_1_12 = self.tool_config.is_at_least_version("1.1.12")
+    is_at_least_version_2_0_0  = self.tool_config.is_at_least_version("2.0.0")
+    is_at_least_version_2_1_0  = self.tool_config.is_at_least_version("2.1.0")
 
     # -----------------------------------------------------------
     # More validations of params that are substituted in commands
@@ -228,7 +229,7 @@ class CbrainTask::Civet < ClusterTask
       cb_error "Bad model name."         unless params[:model]        =~ /^\s*[\w\.]+\s*$/
       cb_error "Model is not valid for this CIVET version" if params[:model] == "ADNInl"        && !is_version_1_1_12
       cb_error "Model is not valid for this CIVET version" if params[:model] == "icbm152nl_09a" && !is_at_least_version_2_0_0
-      cb_error "Model is not valid for this CIVET version" if params[:model] == "icbm152nl_09s" && !is_at_least_version_2_0_0
+      cb_error "Model is not valid for this CIVET version" if params[:model] == "icbm152nl_09s" && !is_at_least_version_1_1_12
       cb_error "Model is not valid for this CIVET version" if params[:model] == "ADNIhires"     && !is_at_least_version_2_0_0
     end
 
@@ -345,7 +346,7 @@ class CbrainTask::Civet < ClusterTask
     if mybool(params[:VBM])
         args += "-VBM "
         args += "-VBM-symmetry "                                if mybool(params[:VBM_symmetry])
-        args += "-VBM-cerebellum "                              if mybool(params[:VBM_cerebellum])
+        args += "-no-VBM-cerebellum "                           if mybool(params[:mask_VBM_cerebellum])
         args += "-VBM-fwhm #{params[:VBM_fwhm].bash_escape} "   if params[:VBM_fwhm].present?
     end
 

--- a/cbrain_task/civet/portal/civet.rb
+++ b/cbrain_task/civet/portal/civet.rb
@@ -119,7 +119,7 @@ class CbrainTask::Civet < PortalTask
       :VBM                 => "0",         # -[no-]VBM
       :VBM_fwhm            => "8",         # -VBM-fwhm
       :VBM_symmetry        => "0",         # -[no-]VBM-symmetry
-      :VBM_cerebellum      => "1",         # -[no-]VBM-cerebellum
+      :mask_VBM_cerebellum => "0",         # -[no-]VBM-cerebellum
 
       # ANIMAL options
       :animal              => "0",         # -[no-]ANIMAL

--- a/cbrain_task/civet/views/_task_params.html.erb
+++ b/cbrain_task/civet/views/_task_params.html.erb
@@ -42,7 +42,7 @@
   params[:model]  = nil if adninl_disabled.present? && params[:model] == 'ADNInl'
   default_models << [ "ADNInl", "ADNInl", adninl_disabled ]
   # Add icbm152nl_09sfor version >= 2.0.0
-  adni152nl_09s_disabled = not_at_least_2_0_0 ? { :disabled => '1' } : {}
+  adni152nl_09s_disabled = not_at_least_1_1_12 ? { :disabled => '1' } : {}
   params[:model]  = nil if adni152nl_09s_disabled.present? && params[:model] == 'icbm152nl_09s'
   default_models << [ "icbm152nl_09s", "icbm152nl_09s", adni152nl_09s_disabled ]
   # Add ADNIhires for version >= 2.0.0
@@ -51,8 +51,8 @@
   default_models << [ "ADNIhires", "ADNIhires", adnihires_disabled ]
 
 
-  default_template = not_at_least_2_0_0 ? ["1.00"] : ["0.50","0.75","1.00"]
-  default_lsq      = not_at_least_2_1_0 ? [ "6", "9", "12" ] : [ "0", "6", "9", "12" ]
+  default_template = not_at_least_1_1_12 ? ["1.00"] : ["0.50","0.75","1.00"]
+  default_lsq      = not_at_least_2_1_0  ? [ "6", "9", "12" ] : [ "0", "6", "9", "12" ]
 %>
 
 
@@ -110,6 +110,12 @@
 
   <%= form.params_label      :N3_distance, "N3 distance:", :title => "N3 spline distance in mm (suggested values: 200 for 1.5T scan; 125 or 100 for 3T scan; 0 for MP2RAGE scan in later version than 1.1.12)" %>
   <%= form.params_text_field :N3_distance, :size => 4 %>
+
+  <% if @tool_config.is_version("1.1.12")  %>
+    <br>
+    <%= form.params_label     :correct_pve, "Correct PVE:", :title => "Correct PVE" %>   
+    <%= form.params_check_box :correct_pve %>
+  <% end %> 
 
   <% if !not_at_least_2_1_0 %>
     <br>
@@ -252,8 +258,8 @@
 
     <br>
 
-    <%= form.params_label :VBM_cerebellum, "Keep cerebellum in VBM maps:", :title => "Keep cerebellum in VBM maps" %>
-    <%= form.params_check_box :VBM_cerebellum %>
+    <%= form.params_label :mask_VBM_cerebellum, "Mask cerebellum in VBM maps:", :title => "Mask cerebellum in VBM maps" %>
+    <%= form.params_check_box :mask_VBM_cerebellum %>
   </div>
 
 </fieldset>

--- a/cbrain_task/civet/views/public/edit_params_help.html
+++ b/cbrain_task/civet/views/public/edit_params_help.html
@@ -68,7 +68,7 @@
     <li><b>Process VBM files:</b> Process VBM files for analysis, if checked.</li>
     <li><b>Blurring kernel size in mm for volume:</b> Blurring kernel size in mm for volume.</li>
     <li><b>Run symmetry tool:</b> Run symmetry tools, if checked.</li>
-    <li><b>Keep cerebellum in VBM maps:</b> Keep cerebellum in VBM maps, if checked.</li>
+    <li><b>Mask cerebellum in VBM maps:</b> Mask cerebellum in VBM maps, if checked.</li>
 </ul>
 
 <b>ANIMAL options, only for version 2.0.0 and later</b>


### PR DESCRIPTION
Following user need, I added some option for CIVET 1.1.12. It was asked to have the following available in CBRAIN: 

> -headheight 175 -N3-distance 125 -model icbm152nl_09s -lsq12 -template 0.50 -correct-pve -VBM -no-VBM-cerebellum -resample-surfaces -thickness tlaplace 30 -combine-surfaces

In meantime, I fixed the -VBM-cerebellum option, that was never applied, here is the CIVET documentation: 

>    -VBM-cerebellum       keep cerebellum in VBM maps
      -no-VBM-cerebellum    mask out cerebellum in VBM maps [default-VBM-cerebellum]
