### PR TITLE
Updated task descriptors according to what was published on Zenodo

### DIFF
--- a/cbrain_task_descriptors/ICA-AROMA.json
+++ b/cbrain_task_descriptors/ICA-AROMA.json
@@ -1,6 +1,7 @@
 {
     "tool-version": "0.3.1", 
     "name": "ICA_AROMA", 
+    "author": "Maarten Mennes",
     "command-line": "python /ICA-AROMA/ica-aroma-wrapper.py [OUTPUT_DIR] [INPUT_FILE] [AFFINE_FILE] [WARP_FILE] [REALIGNMENT_FILE] [MASK_FILE] [MELODIC_DIR] [FEAT_DIR] [TR_NUM] [DIMS_NUM] [DENOISING_STRATEGY]", 
     "inputs": [
         {
@@ -201,5 +202,8 @@
     "suggested-resources": {
         "walltime-estimate": 5000
     }, 
-    "description": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data."
+    "description": "ICA-AROMA (i.e. Independent Component Analyis-based Automatic Removal Of Motion Artifacts) is a data-driven method to identify and remove motion-related independent components from fMRI data.",
+    "tags": {
+        "domain": "fmri"
+    }
 }

--- a/cbrain_task_descriptors/fsl_bet.json
+++ b/cbrain_task_descriptors/fsl_bet.json
@@ -1,7 +1,14 @@
 {
     "tool-version": "1.0.0", 
     "name": "fsl_bet", 
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_bet.json",
     "command-line": "bet [INPUT_FILE] [MASK] [FRACTIONAL_INTENSITY] [VERTICAL_GRADIENT] [CENTER_OF_GRAVITY] [OVERLAY_FLAG] [BINARY_MASK_FLAG] [APPROX_SKULL_FLAG] [NO_SEG_OUTPUT_FLAG] [VTK_VIEW_FLAG] [HEAD_RADIUS] [THRESHOLDING_FLAG] [ROBUST_ITERS_FLAG] [RES_OPTIC_CLEANUP_FLAG] [REDUCE_BIAS_FLAG] [SLICE_PADDING_FLAG] [MASK_WHOLE_SET_FLAG] [ADD_SURFACES_FLAG] [ADD_SURFACES_T2] [VERBOSE_FLAG] [DEBUG_FLAG]", 
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    }, 
     "inputs": [
         {
             "description": "Input image (e.g. img.nii.gz)", 
@@ -351,5 +358,29 @@
             "name": "Output out-skull mesh off file"
         }
     ], 
+     "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    },
+    "tests": [
+            {
+             "name": "fsl_bet_test",
+             "invocation": {
+                    "infile": "sub-01_T1w.nii.gz",
+                    "maskfile": "img_bet"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outfile",
+                            "md5-reference": "053507dd8605d62f5ba71dbecece17f8"
+                        }
+                    ]
+                }
+        }
+    ],
     "description": "Automated brain extraction tool for FSL"
 }

--- a/cbrain_task_descriptors/fsl_fast.json
+++ b/cbrain_task_descriptors/fsl_fast.json
@@ -1,7 +1,14 @@
 {
     "tool-version": "5.0.0", 
     "name": "fsl_fast", 
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_fast.json",
     "command-line": "fast [NUM_CLASSES] [LOOP_ITERS] [BF_SMOOTHING] [IMG_TYPE] [INIT_SEG_SMOOTHNESS] [BINARY_SEGMENTS] [PRIOR_INIT] [NO_PVE] [BIAS_FIELD] [BIAS_CORR_IMG] [NO_BIAS_RM] [OUTPUT_BASENAME] [PRIORS_THROUGHOUT] [SEG_INIT_ITERS] [MIXEL_SMOOTHNESS] [NUM_MAIN_LOOP_ITERS] [HYPER_SEG_SMOOTHNESS] [VERBOSE] [MANUAL_INTENSITIES_FILE] [OUTPUT_PROB_MAPS] [IN_FILES]; mkdir [OUTPUT_DIRECTORY]; mv [OUTPUT_DIRECTORY]_* [OUTPUT_DIRECTORY]", 
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    }, 
     "inputs": [
         {
             "command-line-flag": "-n", 
@@ -242,5 +249,28 @@
             "name": "Output Directory"
         }
     ], 
+    "tests": [
+            {
+             "name": "fsl_fast_test",
+             "invocation": {
+                    "in_files": "sub-01_T1w.nii.gz",
+                    "output_basename": "img_fast"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "output_dir"
+                        }
+                    ]
+                }
+        }
+    ],
+    "tags": {
+        "domain": [
+            "neuroinformatics",
+            "mri"
+        ]
+    },
     "description": "FAST (FMRIB's Automated Segmentation Tool) segments a 3D image of the brain into different tissue types (Grey Matter, White Matter, CSF, etc.), whilst also correcting for spatial intensity variations (also known as bias field or RF inhomogeneities), via a hidden Markov random field model and an associated EM algorithm. Note that the alternative priors option is not supported at this time."
 }

--- a/cbrain_task_descriptors/fsl_first.json
+++ b/cbrain_task_descriptors/fsl_first.json
@@ -1,7 +1,14 @@
 {
     "tool-version": "5.0.0",
     "name": "fsl_first",
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_first.json",
     "command-line": "mkdir -p [OUTPUT_DIR]; run_first_all [METHOD] [BRAIN_EXTRACTED] [SPECIFIED_STRUCTURE] [AFFINE] [THREE_STAGE] [VERBOSE] [INPUT_FILE] -o [OUTPUT_DIR]/[PREFIX]",
+    "container-image": {
+        "image": "mcin/docker-fsl:latest", 
+        "index": "index.docker.io", 
+        "type": "docker"
+    },
     "inputs": [
         {
             "command-line-flag": "-m",
@@ -93,7 +100,7 @@
 	"value-key": "[OUTPUT_DIR]",
 	"path-template": "[INPUT_FILE]",
 	"list": false,
-	"path-template-stripped-extensions": [".nii",".nii.gz"]
+	"path-template-stripped-extensions": [".nii.gz", ".nii"]
 	},
         {
         "id": "std_sub_outputs",
@@ -101,8 +108,31 @@
         "description": "Std sub output",
         "path-template": "[INPUT_FILE]_to_std_sub*",
         "list": true,
-        "path-template-stripped-extensions": [".nii",".nii.gz"]
+        "path-template-stripped-extensions": [".nii.gz", ".nii"]
         }
     ],
+    "tests": [
+            {
+             "name": "fsl_first_test",
+             "invocation": {
+                    "input_file": "sub-01_T1w.nii.gz",
+                    "prefix": "img_first"
+                },
+                "assertions": {
+                    "exit-code": 0,
+                    "output-files": [
+                        {
+                            "id": "outputs"
+                        }
+                    ]
+                }
+        }
+    ],
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "mri"
+        ]
+    }, 
     "description": "FIRST is a model-based segmentation and registration tool, based on a Bayesian model of shape and appearance for subcortical structures."
 }

--- a/cbrain_task_descriptors/fsl_probtrackx2.json
+++ b/cbrain_task_descriptors/fsl_probtrackx2.json
@@ -1,6 +1,8 @@
 {
     "tool-version": "1.0.0", 
-    "name": "fsl_probtrackx2", 
+    "name": "fsl_probtrackx2",
+    "author": "Oxford Centre for Functional MRI of the Brain (FMRIB)",
+    "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/cbrain_task_descriptors/fsl_probtrackx2.json", 
     "command-line": "cp -rL [INPUT_DIR] [OUTPUT_DIR]; probtrackx2 -s [OUTPUT_DIR]/[BASENAME] -m [OUTPUT_DIR]/[MASKNAME] -x [SEEDFILE] --dir=[OUTPUT_DIR]/[FINALDIR] [FORCEDIR] [OPD] [PD] [OS2T] --targetmasks=[TARGETMASKS] --xfm=[OUTPUT_DIR]/[XFM] --invxfm=[OUTPUT_DIR]/[INVXFM]", 
     "inputs": [
         {
@@ -137,5 +139,11 @@
     "suggested-resources": {
         "walltime-estimate": 331200
     }, 
-    "description": "probabilistic tracking with crossing fibres"
+    "description": "probabilistic tracking with crossing fibres",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "dmri"
+        ]
+    }
 }


### PR DESCRIPTION
Published the following descriptors to Zenodo as per https://github.com/boutiques/boutiques/issues/174:
* https://zenodo.org/record/1445789
* https://zenodo.org/record/1450991
* https://zenodo.org/record/1482743
* https://zenodo.org/record/1494308
* https://zenodo.org/record/1494312

Added to each descriptor:
* Author (used the ones from https://brainhack101.github.io/neurolinks/)
* Tags
* Descriptor URL (except for ICA-AROMA because we decided to add them after I had published that one)

Added container image and tests to fsl_bet, fsl_fast and fsl_first

Switched the order of paths in `path-template-stripped-extensions` for fsl_first because I noticed a bug where, for a file like `file_name.nii.gz`, it would see the `.nii` first and strip that so the file becomes `file_name.gz`