### PR TITLE
Updating the datalad data provider to now use a class that maintains a cached version of the repo.

### DIFF
--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -61,7 +61,7 @@ class DataladDataProvider < DataProvider
   end
 
   def impl_is_alive? #:nodoc:
-    true
+    datalad_repo.connected?
   end
 
   def impl_sync_to_cache(userfile) #:nodoc:

--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -125,7 +125,7 @@ class DataladDataProvider < DataProvider
       dl_full_path = datalad_repo.get_full_cache_with_prefix(name)
 
       # fix type
-      type == :file || type == :gitannexlink ? type = :regular : type
+      type = :regular if type == :file || type == :gitannexlink
 
       next unless allowed_types.include? type
       next if is_excluded?(name)

--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -33,11 +33,10 @@ class DataladDataProvider < DataProvider
   # This returns the datalad repository
   # and if not inititalized, created the datalad_repository class from the variables
   def datalad_repo
-    return @datalad_repo if @datalad_repo
-    @datalad_repo = DataladRepository.new(self.datalad_repository_url,
-                                          self.datalad_relative_path,
-                                          self.id,
-                                          RemoteResource.current_resource.id)
+    @datalad_repo ||= DataladRepository.new(self.datalad_repository_url,
+                                            self.datalad_relative_path,
+                                            self.id,
+                                            RemoteResource.current_resource.id)
   end
 
   def is_browsable?(by_user = nil) #:nodoc:

--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -24,10 +24,20 @@ class DataladDataProvider < DataProvider
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  DATALAD_PREFIX = "http://datasets.datalad.org"
+  validates_presence_of :datalad_repository_url, :datalad_relative_path
 
   def self.pretty_category_name #:nodoc:
-    "Datalad.ORG"
+    "DataladProvider"
+  end
+
+  # This returns the datalad repository
+  # and if not inititalized, created the datalad_repository class from the variables
+  def datalad_repo
+    return @datalad_repo if @datalad_repo
+    @datalad_repo = DataladRepository.new(self.datalad_repository_url,
+                                          self.datalad_relative_path,
+                                          self.id,
+                                          RemoteResource.current_resource.id)
   end
 
   def is_browsable?(by_user = nil) #:nodoc:
@@ -46,8 +56,9 @@ class DataladDataProvider < DataProvider
     false
   end
 
-  def provider_full_path(userfile) #:nodoc:
-    datalad_relative_path(userfile) + userfile.name
+  def provider_full_path(userfile) #:nodoc: # not sure is needed anymore
+    # because this is on the datalad_repository, only the userfile name is needed
+    userfile.name
   end
 
   def impl_is_alive? #:nodoc:
@@ -55,42 +66,15 @@ class DataladDataProvider < DataProvider
   end
 
   def impl_sync_to_cache(userfile) #:nodoc:
-    src         = provider_full_path(userfile)
-    dest        = cache_full_path(userfile)
-    parent      = dest.parent
-    url_src     = Pathname.new(DATALAD_PREFIX) + src
+    src = userfile.name
+    dest = cache_full_path(userfile)
 
     # Prepare receiving area
     mkdir_cache_subdirs(userfile) # DataProvider method core caching subsystem
 
-    # Download.
-    #
-    # Because 'datalad' can be invoked from within a singularity container,
-    # we have to make sure that:
-    # 1) the pwd is set to the userfile cache's parent location;
-    # 2) we provide a full path for the destination too;
-    # 3) we HOPE the singularity setup has 'overlay' support to mount the
-    #    pwd too using the SINGULARITY_BINDPATH environment variable.
-    #
-    # This may seem excessive but datalad in singularity is very brittle.
-    with_modified_env('SINGULARITY_BINDPATH' => cache_rootdir().to_s) do # from BrainPortal/config/initializers/added_core_extensions/kernel.rb
-      datalad_command = "cd #{parent.to_s.bash_escape} ; datalad install -r -g -s #{url_src.to_s.bash_escape} #{dest.to_s.bash_escape}"
-      system(datalad_command)  # the stupid command produces tons of output on stdout
-    end
+    datalad_repo.get_files_into_directory(src,dest,cache_rootdir().to_s)
 
-    # Fix for too restrictive permissions deep in the .git repo
-    system("chmod", "-R", "u+rwx", "#{dest.to_s.bash_escape}/.git")
-
-    # We may have to run 'git-annex uninit' many levels deep;
-    # hopefully our applications are OK with accessing files through
-    # symbolic links?
-    #if userfile.is_a?(FileCollection)
-    #  Dir.chdir(dest.to_s) do
-    #    system("git-annex uninit")
-    #  end
-    #end
-
-    cb_error "Cannot fetch content of '#{userfile.name}' on Datalad site from '#{url_src}'." unless File.exists?(dest.to_s)
+    cb_error "Cannot fetch content of '#{userfile.name}' on Datalad site from '#{datalad_repo.get_url}'." unless File.exists?(dest.to_s)
 
     true
   end
@@ -104,98 +88,79 @@ class DataladDataProvider < DataProvider
   end
 
   def impl_provider_list_all(user = nil) #:nodoc: # user ignored
-    provider_readdir(self.remote_dir.presence || "")
+    provider_readdir("",false)
   end
 
   def impl_provider_collection_index(userfile, directory = :all, allowed_types = :regular) #:nodoc:
-    cb_error "A DataLad DP does not implement a recursive listing of the remote file tree." if directory == :all
-    directory = "." if directory == :top
-    path    = provider_full_path(userfile)
-    path   += Pathname.new(directory) unless directory == '.' || directory.blank?
-    prefix  = Pathname.new(userfile.name)
-    prefix += Pathname.new(directory) unless directory == '.' || directory.blank?
-    provider_readdir(path, allowed_types, prefix)
+    ### Should this be recursive?
+    recursive = directory == :all ? true : false
+    ### fix the right path name
+    directory = directory == :top || directory == :all ? "" : directory
+    path_name = Pathname.new(userfile.name)
+    path_name = directory != "" ? path_name.join(directory) : path_name
+
+    provider_readdir(path_name,recursive)
+
   end
 
   private
-
-  # NOTE: The metadata :datalad_path_prefix is
-  # for a future feature where userfile's DP location
-  # can be prefixed with a subpath; not currently implemented
-  # in browsing or registration.
-  def datalad_relative_path(userfile) #:nodoc:
-    base   = self.remote_dir.presence
-    prefix = (userfile.meta[:datalad_path_prefix] || {})[self.id]
-    path   = base ? Pathname.new(base) : Pathname.new("")
-    path  += prefix if prefix
-    path
-  end
-
-  private
-
   # Low level read of a single directory level. Caches in the Scratch DP.
-  # Very inefficient, but the datalad API is dumb.
-  def provider_readdir(dirname, allowed_types = [ :regular, :directory ], add_prefix = nil) #:nodoc:
+  # Very inefficient, but the datalad API is slow.
+  # Caching information in a json could improve performance, but at the cost of updating dynamically
+  def provider_readdir(dirname, recursive=true, allowed_types = [ :regular, :directory]) #:nodoc:
 
     allowed_types = Array(allowed_types)
     dirname       = dirname.to_s
 
-    # Datalad Caching
-    # We use the SystemScratchSpace data provider for storing the datalad dataset root.
-    # The name of the file might end with an "=" sign if the remote_dir is empty.
-    datalad_cache_userfile_name =
-      "DataLad.rr=#{RemoteResource.current_resource.id}.dp=#{self.id}.dir=#{dirname.gsub("/","_")}"
+    # call the datalad repository list_contents to get everything
+    list = []
 
-    # Fetch the datalad dataset info
-    datalad_cache_userfile = DataladSystemSubset.find_or_create_as_scratch(:name => datalad_cache_userfile_name) do |datalad_cache_dir|
-       system("
-               mkdir -p #{datalad_cache_dir.to_s.bash_escape}
-               cd #{datalad_cache_dir.to_s.bash_escape}
-               datalad install -r --recursion-limit 1 -s #{DATALAD_PREFIX}/#{dirname.bash_escape} #{datalad_cache_dir.to_s.bash_escape}/#{dirname.to_s.bash_escape}
-              "
-             )
-    end
-    datalad_cache_dir = datalad_cache_userfile.cache_full_path
+    uid_to_owner = {}
+    gid_to_group = {}
 
-    # Parse the information
-    json_text = IO.popen("cd #{datalad_cache_dir.to_s.bash_escape}/#{dirname.to_s.bash_escape};datalad ls --json display","r") { |fh| fh.read }
-    entries = JSON.parse(json_text)
-    nodes   = entries["nodes"] || []
+    datalad_repo.list_contents(recursive,dirname).each do |fname|
+      name = fname[:name]
+      size = fname[:size_in_bytes]
+      type = fname[:type]
 
-    # Build and return a list of FileInfo objects to represents the available entries.
-    list = nodes.map do |node|
-      name = node['name']
-      next nil if name == "." || name == ".." # robust
+      dl_full_path = datalad_repo.get_full_cache_with_prefix(name)
 
-      type = node['type']
-      symbolic_type = ( type == 'file' ? :regular :
-                        type =~ /^(uninitialized|dataset|directory|folder|dir)$/i ? :directory :
-                        :unknown )
-      next nil unless allowed_types.include? symbolic_type
+      # fix type
+      type == :file || type == :gitannexlink ? type = :regular : type
 
-      size = node['size']['total'] || "0"
-      size.sub!(/\s*kb/,"000")
-      size.sub!(/\s*mb/,"000000")
-      size.sub!(/\s*gb/,"000000000")
-      size.sub!(/\s*tb/,"000000000000")
-      size = size.to_i
-      datetime = DateTime.parse(node['date'])
+      next unless allowed_types.include? type
+      next if is_excluded?(name)
 
-      fileinfo = FileInfo.new
+      # get stat with lstat
+      stat = File.lstat(dl_full_path)
 
-      fileinfo.name          = add_prefix.to_s.blank? ? name : (Pathname.new(add_prefix) + name).to_s
-      fileinfo.symbolic_type = symbolic_type
+      # Look up user name from uid
+      uid        = stat.uid
+      owner_name = (uid_to_owner[uid] ||= (Etc.getpwuid(uid).name rescue uid.to_s))
+
+      # Lookup group name from gid
+      gid        = stat.gid
+      group_name = (gid_to_group[gid] ||= (Etc.getgrgid(gid).name rescue gid.to_s))
+
+      # Create a FileInfo
+      fileinfo               = FileInfo.new
+      fileinfo.name          = name
+      fileinfo.symbolic_type = type
       fileinfo.size          = size
-      fileinfo.atime         =
-        fileinfo.ctime       =
-        fileinfo.mtime       = datetime
+      fileinfo.permissions   = stat.mode
+      fileinfo.atime         = stat.atime
+      fileinfo.ctime         = stat.ctime
+      fileinfo.mtime         = stat.mtime
+      fileinfo.uid           = uid
+      fileinfo.owner         = owner_name
+      fileinfo.gid           = gid
+      fileinfo.group         = group_name
 
-      fileinfo
-    end.compact
+      list << fileinfo
+    end
 
     list.sort! { |a,b| a.name <=> b.name }
     list
   end
-
 end
 

--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -98,7 +98,7 @@ class DataladDataProvider < DataProvider
     path_name = Pathname.new(userfile.name)
     path_name = directory != "" ? path_name.join(directory) : path_name
 
-    provider_readdir(path_name,recursive)
+    provider_readdir(path_name,recursive,allowed_types)
 
   end
 
@@ -106,7 +106,7 @@ class DataladDataProvider < DataProvider
   # Low level read of a single directory level. Caches in the Scratch DP.
   # Very inefficient, but the datalad API is slow.
   # Caching information in a json could improve performance, but at the cost of updating dynamically
-  def provider_readdir(dirname, recursive=true, allowed_types = [ :regular, :directory]) #:nodoc:
+  def provider_readdir(dirname, recursive=true, allowed_types = [:regular, :directory]) #:nodoc:
 
     allowed_types = Array(allowed_types)
     dirname       = dirname.to_s

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -129,9 +129,12 @@ class DataladRepository
   def get_files_into_directory(src_path,dest_path,cache_rootdir_string="")
     install_repository
 
-    dl_command_string =  "cd #{dest_path.parent.to_s.bash_escape} ; "
-    dl_command_string += "datalad install -r -g -s #{get_url(src_path.to_s.bash_escape)} #{dest_path.to_s.bash_escape}; "
-    dl_command_string += "cd #{dest_path.to_s.bash_escape}; git annex uninit; chmod -R u+rwx .git"
+    dl_command_string =  "
+                          cd #{dest_path.parent.to_s.bash_escape};
+                          datalad install -r -g -s #{get_url(src_path.to_s.bash_escape)} #{dest_path.to_s.bash_escape};
+                          cd #{dest_path.to_s.bash_escape}; git annex uninit; chmod -R u+rwx .git
+                         "
+
     if cache_rootdir_string.blank?
       system(dl_command_string)
     else

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -28,7 +28,6 @@ class DataladRepository
 
   # Establish a connection and install the initial image of the datalad repo in a
   # Temporary cache directory
-
   def initialize(datalad_repository_url, datalad_relative_path,
                  dp_id="", cr_id="")
                  #local_repository_directory, local_cache_file_name)

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -50,7 +50,7 @@ class DataladRepository
 
   def connected?
     ### need to figure out how to tell if I can get stuff from datalad
-    cmd_string = "curl --head -f --connect-timeout 20 #{get_url.bash_escape} > /dev/null 2>>/dev/null"
+    cmd_string = "curl --head -f --connect-timeout 20 #{get_url.bash_escape} > /dev/null 2>/dev/null"
     system(cmd_string)
   rescue
       false

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -134,7 +134,7 @@ class DataladRepository
     if cache_rootdir_string.blank?
       system(dl_command_string)
     else
-      with_modified_env('SINGULARITY BINDPATH' => cache_rootdir_string) do
+      with_modified_env('SINGULARITY_BINDPATH' => cache_rootdir_string) do
         system(dl_command_string)
       end
     end

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -50,7 +50,7 @@ class DataladRepository
 
   def connected?
     ### need to figure out how to tell if I can get stuff from datalad
-    cmd_string = "curl --head -f #{get_url.bash_escape} > /dev/null 2>>/dev/null"
+    cmd_string = "curl --head -f --connect-timeout 20 #{get_url.bash_escape} > /dev/null 2>>/dev/null"
     system(cmd_string)
   rescue
       false

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -33,8 +33,8 @@ class DataladRepository
                  dp_id="", cr_id="")
                  #local_repository_directory, local_cache_file_name)
 
-    @prefix = File.join(datalad_repository_url,datalad_relative_path)
-    @path_prefix = datalad_relative_path
+    @prefix = File.join(datalad_repository_url.strip(),datalad_relative_path.strip())
+    @path_prefix = datalad_relative_path.strip()
 
     # Here we will give a unique name to this repository's cache directory
     # and assign it a Userfile to be able to maintain it, as this is related

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -1,0 +1,167 @@
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Implements a DataProvider that can get files from a Datalad Repository
+#
+# To explore a Datalad Repository, a separate cached version of the repo
+# with the git annex links is to be maintained separately so that we can
+# explore it to find the file metadate.
+#
+# This library will create that cache and use it separately to maintain
+# the file metadata and initiate any datalad or git annex calls that are
+# needed to facilitate the data provider capability
+
+require 'fileutils'
+
+class DataladRepository
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Establish a connection and install the initial image of the datalad repo in a
+  # Temporary cache directory
+
+  def initialize(datalad_repository_url, datalad_relative_path,
+                 dp_id="", cr_id="")
+                 #local_repository_directory, local_cache_file_name)
+
+    @prefix = File.join(datalad_repository_url,datalad_relative_path)
+    @path_prefix = datalad_relative_path
+
+    # Here we will give a unique name to this repository's cache directory
+    # and assign it a Userfile to be able to maintain it, as this is related
+    # to a dataprovider, the dataprovider information can be used to build the
+    # directory name.
+    dp_id_here = dp_id.blank? ? "aaa" : dp_id
+    cr_id_here = cr_id.blank? ? "bbb" : cr_id
+    prefix_clean = @prefix.dup.tr(":/.","_")
+    @cache_dir_name = "Datalad.rr=#{cr_id_here}.dp=#{dp_id_here}.pre=#{prefix_clean}"
+
+    @cache_userfile = DataladSystemSubset.find_or_create_as_scratch(:name => @cache_dir_name) do |cache_dir| end
+    @cache_path = @cache_userfile.cache_full_path
+    self
+  end
+
+  def connected?
+    ### need to figure out how to tell if I can get stuff from datalad
+    install_repository rescue false
+    true
+  end
+  ####################################################################
+  # accessor methods
+  ####################################################################
+  def get_prefix
+    @prefix
+  end
+
+  def get_cache_path
+    @cache_path
+  end
+
+  def get_cache_userfile
+    @cache_userfile
+  end
+
+  ####################################################################
+  # path manipulation methods
+  ####################################################################
+
+  def get_url(relative_path="")
+    relative_path == "" ? @prefix : File.join(@prefix,relative_path)
+  end
+
+  def get_full_cache_path
+    @cache_path
+  end
+
+  def get_full_cache_with_prefix(relative_path="")
+    relative_path == "" ? File.join(@cache_path,File.basename(@path_prefix))
+                        : File.join(@cache_path,File.basename(@path_prefix),relative_path)
+  end
+
+  def get_full_cache_path_for_userfile(userfile="")
+    if userfile == @cache_userfile
+      return @cache_userfile.cache_full_path
+    else
+      return userfile.cache_full_path
+    end
+  end
+  ####################################################################
+  # datalad installation methods
+  ####################################################################
+
+  def install_repository
+   raise "Datalad Repository at #{@prefix} cache_directory not set prior to install" if @cache_path.nil?
+    system("
+           mkdir -p #{get_full_cache_path}
+           cd #{get_full_cache_path}
+           datalad install -r -s #{get_url.bash_escape}
+           "
+      )
+  end
+
+  ####################################################################
+  # Listing files
+  ####################################################################
+
+  def list_contents(recursive=true, path="")
+    #This is slow, I can potentially make faster by bulk operations
+    install_repository
+    dllist = []
+
+    glob_string = recursive ? "#{get_full_cache_with_prefix(path)}/**/*": "#{get_full_cache_with_prefix(path)}/*"
+    Dir.glob(glob_string) do |fname|
+      bname = File.basename(fname)
+      dname = File.dirname(fname)
+      name = fname.gsub("#{get_full_cache_with_prefix}/","")
+
+      next if name == "." || name == ".." || name == ".git" || name == ".datalad"
+      # get metadata that you can only get from git-annex
+      type = File.symlink?(fname) ? :symlink : File.stat(fname).ftype.to_sym rescue nil
+      size = type.to_sym == :file ? File.stat(fname).size.to_i : 0
+
+      if type.to_sym == :symlink
+        ## This seems the most stable wy to get this stuff, go to the directory and git annex info it there
+        git_annex_json_text = IO.popen("cd #{dname}; git annex info #{bname} --fast --json --bytes") { |fh| fh.read }
+        git_annex_json = JSON.parse(git_annex_json_text)
+
+        type = git_annex_json.key?("key") ? :gitannexlink : type
+
+        ### now we parse
+        size = git_annex_json.key?("size") ? git_annex_json['size'].to_i : 0
+      end
+      dllist << {:name => name, :size_in_bytes => size,:type => type}
+    end
+    dllist
+  end
+
+  ####################################################################
+  # Getting the files
+  ####################################################################
+
+  def get_files_into_directory(src_path,dest_path,cache_rootdir_string="")
+    #install_repository
+
+    dl_command_string =  "cd #{dest_path.parent.to_s.bash_escape} ; "
+    dl_command_string += "datalad install -r -g -s #{get_url(src_path)} #{dest_path.to_s.bash_escape}; "
+    dl_command_string += "cd #{dest_path}; git annex uninit; chmod -R u+rwx .git"
+    if cache_rootdir_string.blank?
+      system(dl_command_string)
+    else
+      with_modified_env('SINGULARITY BINDPATH' => cache_rootdir_string) do
+        system(dl_command_string)
+      end
+    end
+  end
+end
+
+
+

--- a/lib/tests/check_dl_dp.rb
+++ b/lib/tests/check_dl_dp.rb
@@ -1,0 +1,112 @@
+
+#
+# Load this file in a console; I suggest running 'no_log' first.
+#
+
+1.times do
+
+# Clean up everything
+DataladDataProvider.where(:name => [ 'auto-test-top', 'auto-test-abide']).each do |dp|
+  dp.userfiles.each do |u|
+    puts "Erasing #{u.to_summary}"
+    u.delete
+  end
+  DataladSystemSubset.where("name like '%dp=#{dp.id}%'").each do |u|
+    puts "Destroying #{u.to_summary}"
+    u.destroy!
+  end
+  puts "Destroying #{dp.to_summary}"
+  dp.reload
+  dp.destroy!
+end
+
+# Create two DPs and one file
+d1=DataladDataProvider.find_or_create_by!(
+  :name => 'auto-test-abide',
+  :user_id  => CoreAdmin.first.id,
+  :group_id => CoreAdmin.first.own_group.id,
+  :online => true,
+  :read_only => false,
+  :not_syncable => false,
+  :datalad_repository_url => 'https://datasets.datalad.org',
+  :datalad_relative_path => 'abide/RawDataBIDS',
+)
+d2=DataladDataProvider.find_or_create_by!(
+  :name => 'auto-test-top',
+  :user_id  => CoreAdmin.first.id,
+  :group_id => CoreAdmin.first.own_group.id,
+  :online => true,
+  :read_only => false,
+  :not_syncable => false,
+  :datalad_repository_url => 'https://datasets.datalad.org',
+  :datalad_relative_path => '/',
+)
+f3=FileCollection.create!(
+  :name => 'MaxMun_b',
+  :user_id => d1.user_id,
+  :group_id => d1.group_id,
+  :size => 144639235,
+  :data_provider_id => d1.id,
+  :num_files => 32,
+)
+
+puts_red "Browsing DP1"
+list1 = d1.provider_list_all
+sc1 = ScratchDataProvider.main.userfiles.last
+puts_blue "LS of #{sc1.cache_full_path}/BrowseTop"
+system "ls #{sc1.cache_full_path}/BrowseTop"
+cb_error "No good" unless list1.any? { |f| f.name == 'CMU_a' }
+
+puts_red "Browsing DP2"
+list2 = d2.provider_list_all
+sc2 = ScratchDataProvider.main.userfiles.last
+puts_blue "LS of #{sc2.cache_full_path}/BrowseTop"
+system "ls #{sc2.cache_full_path}/BrowseTop"
+cb_error "No good" unless list2.any? { |f| f.name == 'abide' }
+
+# provider_collection_index vs cache_collection_index tests
+tests = [
+  [ ],
+  [ :top, [:regular, :directory] ],
+  [ :top, :directory ],
+  [ :all ],
+  [ :all, [:regular, :directory] ],
+  [ :all, :directory ],
+  [ "sub-0051323" ],
+  [ "sub-0051323", :regular ],
+  [ "sub-0051323", [ :regular, :directory] ],
+  [ ".", [ :regular, :directory] ],
+]
+
+dump_fis = lambda { |fis| fis.sort { |a,b| a.name <=> b.name }.each { |fi|
+                    printf "%9s %10d %s\n",fi.symbolic_type,fi.size,fi.name } }
+type_names = lambda { |fis| fis.sort { |a,b| a.name <=> b.name }.map { |fi|
+                      "#{fi.symbolic_type}-#{fi.symbolic_type == :directory ? 0 : fi.size}-#{fi.name}" }.join("\n") }
+
+res = {}
+tests.each do |args|
+  puts "\n\n\n"
+  puts_magenta "LISTING MAXMUN #{args.inspect}"
+  mm=f3.provider_collection_index(*args)
+  dump_fis.(mm)
+  tn = type_names.(mm)
+  res[args] = tn
+end
+
+puts_red "SYNCING TO CACHE"
+f3.sync_to_cache
+
+tests.each do |args|
+  puts "\n\n\n"
+  puts_magenta "LISTING MAXMUN #{args.inspect}"
+  mm=f3.cache_collection_index(*args)
+  dump_fis.(mm)
+  tn = type_names.(mm)
+  if (res[args] != tn)
+    puts_red "DIFFER FOR #{args}!!!"
+    puts_green  "PROV:\n#{res[args]}"
+    puts_yellow "CACHE:\n#{tn}"
+  end
+end
+
+end


### PR DESCRIPTION
We can navigate and get the metadata for the files in a file collection. Still only works for reading and will be associated with a pull request to the main repo that alters the database as now there are two new variables that need to be defined for a datalad repo.