### PR TITLE
UTF8 support in mincfile viewer for info/header

### DIFF
--- a/userfiles/minc_file/views/_info_header.html.erb
+++ b/userfiles/minc_file/views/_info_header.html.erb
@@ -29,10 +29,12 @@ escaped_path = cache_path.to_s.bash_escape
 minc_info = IO.popen("mincinfo #{escaped_path}", "r") do |fh|
   fh.read rescue "Cannot run mincinfo ?!?"
 end
+minc_info = minc_info.text_file_content_to_utf8 # provided by BrainPortal/lib/cbrain_extensions/string_extensions/utilities.rb
 
 minc_head = IO.popen("mincheader #{escaped_path}", "r") do |fh|
   fh.read rescue "Cannot run mincheader ?!?"
 end
+minc_head = minc_head.text_file_content_to_utf8 # provided by BrainPortal/lib/cbrain_extensions/string_extensions/utilities.rb
 %>
 
 <%= build_tabs do |tb| %>


### PR DESCRIPTION
I discovered that some people put text information in non-UTF8 format in the text fields of some minc files, so that when we were trying to show the output of mincheader we got encoding errors in the templates.

This should fix that, we already had a nice utility to guess encoding of strings, or force them if necessary.