### PR TITLE
New datalad data provider code.

### DIFF
--- a/lib/datalad_data_provider.rb
+++ b/lib/datalad_data_provider.rb
@@ -20,11 +20,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# This class implements a DataProvider that can
+# fetch files and directories from a Datalad
+# remote storage.
 class DataladDataProvider < DataProvider
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  validates_presence_of :datalad_repository_url, :datalad_relative_path
+  validates_presence_of :datalad_repository_url
+  validate              :relative_path_is_it
   before_validation     :strip_datalad_info
 
   def self.pretty_category_name #:nodoc:
@@ -38,11 +42,13 @@ class DataladDataProvider < DataProvider
     true
   end
 
-  def datalad_repo
-    @datalad_repo ||= DataladRepository.new(self.datalad_repository_url,
-                                            self.datalad_relative_path,
-                                            self.id,
-                                            RemoteResource.current_resource.id)
+  # Makes sure the subpath is relative.
+  def relative_path_is_it #:nodoc:
+    if Pathname.new(self.datalad_relative_path).absolute? || self.datalad_relative_path.to_s =~ /\.\./
+      errors.add(:datalad_relative_path, ' must be a relative path')
+      return false
+    end
+    true
   end
 
   def is_browsable?(by_user = nil) #:nodoc:
@@ -61,17 +67,27 @@ class DataladDataProvider < DataProvider
     false
   end
 
-  def provider_full_path(userfile) #:nodoc: # not sure is needed anymore
-    datalad_repo.url_for_userfile(userfile)
+  # Not a full path, a relative path in this implementation!
+  def provider_full_path(userfile) #:nodoc:
+    Pathname.new(self.datalad_relative_path) + userfile.name
   end
 
   def impl_is_alive? #:nodoc:
-    datalad_repo.connected?
+    DataladRepository.remote_reachable?(self.datalad_repository_url)
   end
 
   def impl_sync_to_cache(userfile) #:nodoc:
+    datalad_repo.get_and_uninit!( provider_full_path(userfile) )
+
+    needslash = userfile.is_a?(FileCollection) ? "/" : ""
+    source    = datalad_repo.install_path + self.datalad_relative_path + userfile.name
+
     mkdir_cache_subdirs(userfile)
-    datalad_repo.download_userfile_to_cache(userfile)
+    dest      = userfile.cache_full_path
+
+    rsyncout = bash_this("rsync -a -l --no-p --no-g --chmod=u=rwX,g=rX,o=r --delete #{self.rsync_excludes} #{shell_escape(source)}#{needslash} #{shell_escape(dest)} 2>&1")
+    cb_error "Failed to rsync local file '#{source}' to cache file '#{dest}';\nrsync reported: #{rsyncout}" unless rsyncout.blank?
+
     true
   end
 
@@ -84,41 +100,86 @@ class DataladDataProvider < DataProvider
   end
 
   def impl_provider_list_all(user = nil) #:nodoc: # user ignored
-    subset_cache = datalad_repo.install_subset_for_browsing
-    provider_readdir(subset_cache,false)
+    provider_readdir(self.datalad_relative_path.presence || ".", false)
   end
 
   def impl_provider_collection_index(userfile, directory = :all, allowed_types = :regular) #:nodoc:
-    subset_cache = datalad_repo.install_subset_for_userfile(userfile)
-
     ### Should this be recursive?
     recursive = directory == :all ? true : false
 
     ### fix the right path name
     directory = "" if directory == :top || directory == :all || directory == '.'
-    path_name = File.join(subset_cache, directory).sub(/\/$/,"")
+    subpath   = Pathname.new(self.datalad_relative_path) + userfile.name + directory
 
     # Scan tree on filesystem
-    subtree = provider_readdir(path_name,recursive,allowed_types)
+    subtree = provider_readdir(subpath,recursive,allowed_types)
 
     # Re-insert prefix path for all entries
-    prefix_path = File.join(userfile.name,directory)
-    subtree.each { |fi| fi.name = File.join(prefix_path,fi.name) }
+    if userfile.is_a?(FileCollection)
+      prefix_path = File.join(userfile.name,directory)
+      subtree.each { |fi| fi.name = File.join(prefix_path,fi.name) }
+    end
     subtree
   end
 
   private
 
+  # Name of the automatically-created userfile that
+  # holds the datalad install
+  def default_name_of_userfile_for_datalad_cache
+    "TopDatalad.rr=#{RemoteResource.current_resource.id}.dp=#{self.id}"
+  end
+
+  # The datalad installation tree is cached in a standard userfile.
+  # The administrator has the liberty to configure this in two ways:
+  # 1) automatic and transparent, it will be a file created on demand
+  # in the special ScratchDataProvider
+  # 2) manually, it can be a DataladSystemSubset registered on any standard data
+  # provider; the datalad 'install' command will have to be run manually too.
+  def userfile_for_datalad_cache
+    return @userfile_for_datalad_cache if @userfile_for_datalad_cache
+
+    # Option 1: admin has configured a file by ID manually
+    custom_id = self.meta[:datalad_system_subset_id].presence
+    if custom_id
+      @userfile_for_datalad_cache = DataladSystemSubset.where(:id => custom_id).first
+      return @userfile_for_datalad_cache if @userfile_for_datalad_cache
+    end
+
+    # Option 2: we cache in the scratch space, on demand
+    @userfile_for_datalad_cache = DataladSystemSubset.find_or_create_as_scratch(
+      :name => default_name_of_userfile_for_datalad_cache()
+    ) do |cache_full_path|
+      dlr = DataladRepository.new(cache_full_path)
+      dlr.install_from_url!( self.datalad_repository_url )
+      dlr.install_r!( self.datalad_relative_path ) if self.datalad_relative_path.present?
+    end
+    @userfile_for_datalad_cache
+  end
+
+  # Returns a DataladRepository handler that provides
+  # an api to a file system instance of a datalad install tree
+  def datalad_repo
+    userfile_for_datalad_cache.sync_to_cache
+    @datalad_repo ||= DataladRepository.new(
+      userfile_for_datalad_cache.cache_full_path
+    )
+  end
+
   # This method invokes the method
   #
-  #   DataladRepository.list_contents_from_dataset
+  #   list_contents_from_dataset()
   #
-  # and build a list of FileInfo objects out of the
+  # on the DalataRepository object used to maintain the
+  # cached repository, and builds a list of FileInfo objects out of the
   # returned array.
   def provider_readdir(dirname, recursive=true, allowed_types = [:regular, :directory]) #:nodoc:
 
-    dirname       = Pathname.new(dirname)
+    dirname       = Pathname.new(dirname) # it's possible dirname to point to a file, in fact
     allowed_types = Array(allowed_types)
+
+    full_dirname  = datalad_repo.install_path + dirname
+    is_dir        = true if File.directory?(full_dirname)
 
     list = []
 
@@ -128,14 +189,14 @@ class DataladDataProvider < DataProvider
 
     # Call the datalad repository method to get the short
     # reports about each entry
-    DataladRepository.list_contents_from_dataset(dirname,recursive).each do |fname|
+    datalad_repo.list_contents_from_dataset(dirname,recursive).each do |fname|
 
       # There are only three attributes in the reports
       name = fname[:name]          # relative path, e.g. "a/b/c.txt"
       size = fname[:size_in_bytes]
       type = fname[:type]
 
-      dl_full_path = dirname.join(name)
+      dl_full_path = is_dir ? full_dirname + name : full_dirname
 
       # fix type
       type = :regular if type == :file || type == :gitannexlink

--- a/lib/datalad_repository.rb
+++ b/lib/datalad_repository.rb
@@ -1,3 +1,13 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
@@ -10,162 +20,158 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Implements a DataProvider that can get files from a Datalad Repository
-#
-# To explore a Datalad Repository, a separate cached version of the repo
-# with the git annex links is to be maintained separately so that we can
-# explore it to find the file metadate.
-#
-# This library will create that cache and use it separately to maintain
-# the file metadata and initiate any datalad or git annex calls that are
-# needed to facilitate the data provider capability
-
 require 'fileutils'
 
+# This library handles some elementary operation on a local datalad
+# repository, mosly used when that repo is a cache for a DataladDataProvider.
+#
+#   handler = DataladRepository.new('/path/to/repo') # 'repo' might not yet exist
 class DataladRepository
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  # Establish a connection and install the initial image of the datalad repo in a
-  # Temporary cache directory
-  def initialize(datalad_repository_url, datalad_relative_path, dp_id, cr_id)
-    @base_url     = datalad_repository_url
-    @url_rel_path = datalad_relative_path
-    @dp_id        = dp_id
-    @cr_id        = cr_id
-    self
+  attr_reader :install_path
+
+  # The only object state is the path where the datalad repo is installed
+  def initialize(install_path)
+    @install_path = Pathname.new(install_path)
   end
 
-  def connected?
-    cmd_string = "curl --head -f --connect-timeout 20 #{@base_url.bash_escape} > /dev/null 2> /dev/null"
+  # Checks the URL with curl and makes sure we can connect to it.
+  # Max timeout: 20 seconds
+  def self.remote_reachable?(url)
+    cmd_string = "curl --head -f --connect-timeout 20 #{url.bash_escape} > /dev/null 2> /dev/null"
     system(cmd_string)
   rescue
     false
   end
 
-
-
-  ####################################################################
-  # Browsing Support
-  ####################################################################
-
-  def url_for_browsing
-    File.join(@base_url, @url_rel_path)
-  end
-
-  def name_of_cache_for_browsing
-    "Datalad.rr=#{@cr_id}.dp=#{@dp_id}"
-  end
-
-  def install_subset_for_browsing
-    cache_browsing = DataladSystemSubset.find_or_create_as_scratch(
-      :name => name_of_cache_for_browsing()
-    ) do |cache_dir|
-      retcode = run_datalad_commands(cache_dir,
-        "
-          datalad install -s #{url_for_browsing} BrowseTop || exit 41
-          cd BrowseTop                                     || exit 42
-          git pull                                         || exit 42
-        "
-      )
-      cb_error "Could not run datalad install for browsing."                    if retcode == 41
-      cb_error "Could not run update dataset for browsing."                     if retcode == 42
-      cb_error "Error occured when running datalad script: retcode=#{retcode}"  if retcode > 0
-    end
-    # We need to return on more level of directory after install.
-    cache_browsing.cache_full_path.join('BrowseTop')
-  end
-
-
-
-  ####################################################################
-  # Provider-side support for examining remote userfile
-  ####################################################################
-
-  def url_for_userfile(userfile)
-    File.join(url_for_browsing,userfile.name)
-  end
-
-  def name_of_cache_for_userfile(userfile)
-    name_of_cache_for_browsing() + ".f=#{userfile.id}"
-  end
-
-  def install_subset_for_userfile(userfile)
-    url = url_for_userfile(userfile)
-    cache_userfile = DataladSystemSubset.find_or_create_as_scratch(
-      :name => name_of_cache_for_userfile(userfile)
-    ) do |cache_dir|
-      retcode = run_datalad_commands(cache_dir,
-        "
-          datalad install -r -s #{url.bash_escape} #{userfile.name.bash_escape} || exit 41
-          cd #{userfile.name.bash_escape}                                       || exit 42
-          git pull                                                              || exit 42
-        "
-      )
-      cb_error "Could not run datalad install for subset userfile ##{userfile.id}." if retcode == 41
-      cb_error "Could not run update dataset after install."                        if retcode == 42
-      cb_error "Error occured when running datalad script: retcode=#{retcode}"      if retcode > 0
-    end
-    # We need to return on more level of directory after install.
-    File.join(cache_userfile.cache_full_path,userfile.name)
-  end
-
-
-
-  ####################################################################
-  # Provider-side support for fully downloading a userfile
-  ####################################################################
-
-  def download_userfile_to_cache(userfile)
-    cache_loc = userfile.cache_full_path
-    parent    = cache_loc.parent.to_s
-    url       = url_for_userfile(userfile)
-    myrand      = rand(1000000) # used in background delete
+  # Given a url, will install the remote datalad repo under the install_path.
+  # Normally only needed to be done once.
+  def install_from_url!(url)
+    parent   = install_path.parent
+    basename = install_path.basename.to_s
     retcode = run_datalad_commands(parent,
       "
-        if test -e #{userfile.name.bash_escape} ; then
-          mv #{userfile.name.bash_escape} #{userfile.name.bash_escape}.#{myrand}
-          rm -rf #{userfile.name.bash_escape}.#{myrand} &
-        fi
-        datalad install -r -g -s #{url.bash_escape} #{userfile.name.bash_escape} || exit 41
-        cd #{userfile.name.bash_escape}                                          || exit 42
-        git annex uninit                                                         || exit 51
-        chmod u+rwX .git .datalad
-        rm -rf .git .datalad
-        true
+        datalad install -s #{url} #{basename.bash_escape} >/dev/null 2>&1 || exit 41
+        cd #{basename.bash_escape}                                        || exit 42
+        git pull                                          >/dev/null      || exit 42
       "
     )
-    cb_error "Could not run datalad install for caching userfile ##{userfile.id}." if retcode == 41
-    cb_error "Could not chdir to #{cache_loc}"                                     if retcode == 42
-    cb_error "git annex uninit failed in #{cache_loc}"                             if retcode == 51
-    cb_error "Error occured when running datalad script: retcode=#{retcode}"       if retcode > 0
-    cb_error "Could not download data for userfile" unless Dir.exist?(cache_loc.to_s)
+    cb_error "Could not run datalad install."                                 if retcode == 41
+    cb_error "Could not update datalad dataset."                              if retcode == 42
+    cb_error "Error occured when running datalad script: retcode=#{retcode}"  if retcode > 0
     true
   end
 
+  # Given an installed repo, will install any subcomponent (directory or
+  # file) underneath it.
+  def install_r!(subpath)
+    retcode  = run_datalad_commands(install_path,
+      "
+        datalad install -r #{subpath.to_s.bash_escape} >/dev/null 2>&1 || exit 41
+      "
+    )
+    cb_error "Could not run datalad install subpath command."                if retcode == 41
+    cb_error "Error occured when running datalad script: retcode=#{retcode}" if retcode > 0
+    true
+  end
 
+  # Given a subcomponent that has been installed, will get the actual content.
+  # Applied to a subdirectory, is always recursive.
+  def get!(subpath)
+    fulldest = install_path + subpath
+    parent   = fulldest.parent
+    basename = fulldest.basename
+    retcode  = run_datalad_commands(parent,
+      "
+        datalad get #{basename.to_s.bash_escape} >/dev/null 2>&1 || exit 41
+      "
+    )
+    cb_error "Could not run datalad get command."                            if retcode == 41
+    cb_error "Error occured when running datalad script: retcode=#{retcode}" if retcode > 0
+    true
+  end
+
+  # Given a subpath that has been installed and the data file gotten with get!(),
+  # will run the git-annex 'uninit' command to transform all symbolic links into
+  # their real files. Destructive on the datalad repo, but can still be done several times
+  # without harm.
+  def uninit!(subpath)
+    # Alright, this is really stupid but "git-annex uninit" requires
+    # that it be run with its cwd set to the git top level. So we need
+    # to go up the hierarchy and find .git and rewrite 'subpath' to contain
+    # just the components down from there. Messy
+    fulldest             = install_path + subpath # /inst1/inst2/subpath1/subpath2, subpath2 might be a file or directory
+    git_top, rel_subpath = search_parent_git(fulldest)
+    cb_error "Could not find .git repo within dataset" if git_top.to_s.size < install_path.to_s.size
+
+    retcode  = run_datalad_commands(git_top,
+      "
+        git-annex uninit #{rel_subpath.to_s.bash_escape} >/dev/null 2>&1
+        test $? -gt 1 && exit 41
+        true
+      "
+    )
+    cb_error "Could not run git-annex uninit command."                       if retcode == 41
+    cb_error "Error occured when running datalad script: retcode=#{retcode}" if retcode > 0
+    true
+  end
+
+  # Search a file structure up until .git is found; returns
+  # the path to the parent of .git and the components below
+  # that were in the argument 'path'. E.g. given
+  #
+  #   /data/something/cbrain/BrainPortal/app/models/user.rb
+  #
+  # where the .git is under 'cbrain', the method would return
+  #
+  #   [ "/data/something/cbrain", "BrainPortal/app/models/user.rb" ]
+  def search_parent_git(path)
+    git_top       = Pathname.new(path)
+    short_subpath = Pathname.new('.')
+    while git_top.to_s.size > 1
+      break if (git_top + ".git").exist? #  /inst1/inst2/subpath1/subpath2/.git (subpath2 might be a file)
+      short_subpath = git_top.basename + short_subpath
+      git_top = git_top.parent # move up
+    end
+    [ git_top, short_subpath ]
+  end
+
+  # Runs both get! and uninit!
+  def get_and_uninit!(subpath)
+    self.get!(subpath) && self.uninit!(subpath)
+  end
 
   ####################################################################
   # Listing files
   ####################################################################
 
-  # This method scans a local dirctory containing a datalad subset
+  # This method scans a local directory containing a datalad subset
   # and returns small objects for each entries in it, with
   # three components: :name, :size_in_bytes, and :type .
   # Since a datalad subset is a git annex structure it will
   # query information using git-annex when a symlink is found
   # and then pretend that it is a normal file.
-  def self.list_contents_from_dataset(path,recursive=false)
+  def list_contents_from_dataset(subpath, recursive=false) #:nodoc:
+
+    cb_error "Subpath must be relative" unless Pathname.new(subpath).relative?
+
+    fulldest = install_path + subpath
+    if File.directory?(fulldest)
+      glob_string = recursive ? "#{fulldest}/**/*": "#{fulldest}/*"
+    else
+      glob_string = fulldest # the file itself and nothing more
+    end
+
     dllist = []
-
-    glob_string = recursive ? "#{path}/**/*": "#{path}/*"
-
     Dir.glob(glob_string) do |fname|
-      bname = File.basename(fname)
-      dname = File.dirname(fname)
-      name  = fname.sub("#{path}/","")
+      bname = File.basename(fname)                      # abc.txt
+      dname = File.dirname(fname)                       # /path/dataladroot/subpath/subdir/abc.txt
+      name  = fname.sub("#{fulldest}","").sub(/^\//,"") # subdir/abc.txt
+      name  = bname if name.blank? # when we have just a file
 
-      next if name == "." || name == ".." || name == ".datalad" || name =~ /^\.git/
+      next if bname == "." || bname == ".." || bname == ".datalad" || bname =~ /^\.git/
 
       # get metadata that you can only get from git-annex
       stat = File.lstat(fname)
@@ -174,20 +180,18 @@ class DataladRepository
       size = stat.size.to_i if type.to_sym == :file
 
       if type == :symlink
-        ## This seems the most stable wy to get this stuff, go to the directory and git annex info it there
+        ## This seems the most stable way to get this stuff, go to the directory and git annex info it there
         git_annex_json_text = IO.popen("cd #{dname.bash_escape}; git annex info #{bname.bash_escape} --fast --json --bytes") { |fh| fh.read }
         git_annex_json = JSON.parse(git_annex_json_text) rescue {}
         type = :gitannexlink               if git_annex_json.has_key?("key")
         size = git_annex_json['size'].to_i if git_annex_json.has_key?("size")
       end
 
-      dllist << {:name => name, :size_in_bytes => size,:type => type}
+      dllist << {:name => name, :size_in_bytes => size, :type => type}
     end
 
     dllist
   end
-
-
 
   ####################################################################
   # Internal methods
@@ -205,26 +209,23 @@ class DataladRepository
   # 1) the pwd is set to the parent of where the datalad command will create files
   # 2) we provide a FULL path for the destination too (this must be true in +commands+ too)
   # 3) we HOPE the singularity setup has 'overlay' support to mount the
-  #    pwd too using the SINGULARITY_BINDPATH environment variable.
+  #    datalad root (install_path) too using the SINGULARITY_BINDPATH environment variable.
   #
   # This may seem excessive but datalad in singularity is very brittle.
-  def run_datalad_commands(indir, commands)
-    indir = Pathname.new(indir).realdirpath.to_s # make full; last component may not exist
-    retcode = with_modified_env('SINGULARITY_BINDPATH' => indir) do
-      system("
-              mkdir -p #{indir.bash_escape} || exit 31
-              cd       #{indir.bash_escape} || exit 32
-              #{commands}
-             ")
-      $?.exitstatus
-    end
+  def run_datalad_commands(indir, commands) #:nodoc:
+    indir    = Pathname.new(indir).realdirpath.to_s # make full; last component may not exist
+    bindpath = install_path.parent.to_s
+    system("
+            export SINGULARITY_BINDPATH=#{bindpath.bash_escape}
+            mkdir -p #{indir.bash_escape} || exit 31
+            cd       #{indir.bash_escape} || exit 32
+            #{commands}
+           ")
+    retcode = $?.exitstatus
     cb_error "Could not mkdir '#{indir}'" if retcode == 31
     cb_error "Could not chdir '#{indir}'" if retcode == 32
     retcode
   end
 
-
 end
-
-
 

--- a/lib/tests/check_dl_dp2.rb
+++ b/lib/tests/check_dl_dp2.rb
@@ -1,0 +1,112 @@
+
+#
+# Load this file in a console; I suggest running 'no_log' first.
+#
+
+1.times do
+
+# Clean up everything
+DataladDataProvider.where(:name => [ 'auto-test-top', 'auto-test-abide']).each do |dp|
+  dp.userfiles.each do |u|
+    puts "Erasing #{u.to_summary}"
+    u.delete
+  end
+  DataladSystemSubset.where("name like '%dp=#{dp.id}%'").each do |u|
+    puts "Destroying #{u.to_summary}"
+    u.destroy!
+  end
+  puts "Destroying #{dp.to_summary}"
+  dp.reload
+  dp.destroy!
+end
+
+# Create two DPs and one file
+d1=DataladDataProvider.find_or_create_by!(
+  :name => 'auto-test-abide',
+  :user_id  => CoreAdmin.first.id,
+  :group_id => CoreAdmin.first.own_group.id,
+  :online => true,
+  :read_only => false,
+  :not_syncable => false,
+  :datalad_repository_url => 'https://datasets.datalad.org/abide',
+  :datalad_relative_path => 'RawDataBIDS',
+)
+d2=DataladDataProvider.find_or_create_by!(
+  :name => 'auto-test-top',
+  :user_id  => CoreAdmin.first.id,
+  :group_id => CoreAdmin.first.own_group.id,
+  :online => true,
+  :read_only => false,
+  :not_syncable => false,
+  :datalad_repository_url => 'https://datasets.datalad.org',
+  :datalad_relative_path => '',
+)
+f3=FileCollection.create!(
+  :name => 'MaxMun_b',
+  :user_id => d1.user_id,
+  :group_id => d1.group_id,
+  :size => 144639235,
+  :data_provider_id => d1.id,
+  :num_files => 32,
+)
+
+puts_red "Browsing DP1"
+list1 = d1.provider_list_all
+sc1 = ScratchDataProvider.main.userfiles.last
+puts_blue "LS of #{sc1.cache_full_path}"
+system "ls #{sc1.cache_full_path}"
+cb_error "No good" unless list1.any? { |f| f.name == 'CMU_a' }
+
+puts_red "Browsing DP2"
+list2 = d2.provider_list_all
+sc2 = ScratchDataProvider.main.userfiles.last
+puts_blue "LS of #{sc2.cache_full_path}"
+system "ls #{sc2.cache_full_path}"
+cb_error "No good" unless list2.any? { |f| f.name == 'abide' }
+
+# provider_collection_index vs cache_collection_index tests
+tests = [
+  [ ],
+  [ :top, [:regular, :directory] ],
+  [ :top, :directory ],
+  [ :all ],
+  [ :all, [:regular, :directory] ],
+  [ :all, :directory ],
+  [ "sub-0051323" ],
+  [ "sub-0051323", :regular ],
+  [ "sub-0051323", [ :regular, :directory] ],
+  [ ".", [ :regular, :directory] ],
+]
+
+dump_fis = lambda { |fis| fis.sort { |a,b| a.name <=> b.name }.each { |fi|
+                    printf "%9s %10d %s\n",fi.symbolic_type,fi.size,fi.name } }
+type_names = lambda { |fis| fis.sort { |a,b| a.name <=> b.name }.map { |fi|
+                      "#{fi.symbolic_type}-#{fi.symbolic_type == :directory ? 0 : fi.size}-#{fi.name}" }.join("\n") }
+
+res = {}
+tests.each do |args|
+  puts "\n\n\n"
+  puts_magenta "LISTING MAXMUN #{args.inspect}"
+  mm=f3.provider_collection_index(*args)
+  dump_fis.(mm)
+  tn = type_names.(mm)
+  res[args] = tn
+end
+
+puts_red "SYNCING TO CACHE"
+f3.sync_to_cache
+
+tests.each do |args|
+  puts "\n\n\n"
+  puts_magenta "LISTING MAXMUN #{args.inspect}"
+  mm=f3.cache_collection_index(*args)
+  dump_fis.(mm)
+  tn = type_names.(mm)
+  if (res[args] != tn)
+    puts_red "DIFFER FOR #{args}!!!"
+    puts_green  "PROV:\n#{res[args]}"
+    puts_yellow "CACHE:\n#{tn}"
+  end
+end
+
+end


### PR DESCRIPTION
The caching system and overall architecture was
redesigned to properly handle any subpath that
is registered as a userfile. (The previous code
only worked when under a dl repo was another dl repo)

A new feature is that the admin can elect to cache
the DP repo using the CBRAIN caching system local
on each RemoteResource, or to register a DataladSystemSubset
as a standard userfile to hold the cache (and in this
case it will benefit from the CBRAIN caching system
for transfering a copy of the repo between RRs)

This should be backwards compatible with existing
DataladDataProviders configured.