### PR TITLE
Bugfix for snakemake locking

### DIFF
--- a/boutiques_descriptors/hippunfold_1_0_0.json
+++ b/boutiques_descriptors/hippunfold_1_0_0.json
@@ -9,7 +9,7 @@
   "schema-version": "0.5",
   "author":         "Khan Computational Imaging Lab ",
   "description":    "BIDS App for Hippocampal AutoTop (automated hippocampal unfolding and subfield segmentation)",
-  "command-line": "hippunfold [SUBJECT_DIR] [OUTPUT_DIR] participant [MODALITY] [DERIVATIVES] [SKIP_PREPROC] [SKIP_COREG] [SKIP_INJECT_TEMPLATE_LABELS] [INJECT_TEMPLATE_SMOOTHING_FACTOR] [RIGID_REG_TEMPLATE] [NO_REG_TEMPLATE] [TEMPLATE] [T1_REG_TEMPLATE] [NNUNET_DISABLE_TTA] [OUTPUT_SPACES] [OUTPUT_DENSITY] [HEMI] [LAMINAR_COORDS_METHOD] [KEEP_WORK] [FORCE_NNUNET_MODEL] -c all --unlock",
+  "command-line": "hippunfold [SUBJECT_DIR] [OUTPUT_DIR] participant [MODALITY] [DERIVATIVES] [SKIP_PREPROC] [SKIP_COREG] [SKIP_INJECT_TEMPLATE_LABELS] [INJECT_TEMPLATE_SMOOTHING_FACTOR] [RIGID_REG_TEMPLATE] [NO_REG_TEMPLATE] [TEMPLATE] [T1_REG_TEMPLATE] [NNUNET_DISABLE_TTA] [OUTPUT_SPACES] [OUTPUT_DENSITY] [HEMI] [LAMINAR_COORDS_METHOD] [KEEP_WORK] [FORCE_NNUNET_MODEL] -c all --nolock",
   "inputs": [
       {
         "description": "subject folder for BIDS (folders name should be sub-XXXXX).",

--- a/boutiques_descriptors/hippunfold_1_1_0.json
+++ b/boutiques_descriptors/hippunfold_1_1_0.json
@@ -9,7 +9,7 @@
   "schema-version": "0.5",
   "author":         "Khan Computational Imaging Lab ",
   "description":    "BIDS App for Hippocampal AutoTop (automated hippocampal unfolding and subfield segmentation)",
-  "command-line": "hippunfold [SUBJECT_DIR] [OUTPUT_DIR] participant [MODALITY] [DERIVATIVES] [SKIP_PREPROC] [SKIP_COREG] [SKIP_INJECT_TEMPLATE_LABELS] [INJECT_TEMPLATE_SMOOTHING_FACTOR] [RIGID_REG_TEMPLATE] [NO_REG_TEMPLATE] [TEMPLATE] [ATLAS] [T1_REG_TEMPLATE] [GENERATE_MYELIN_MAP] [NNUNET_ENABLE_TTA] [OUTPUT_SPACES] [OUTPUT_DENSITY] [HEMI] [LAMINAR_COORDS_METHOD] [KEEP_WORK] [FORCE_NNUNET_MODEL] -c all --unlock",
+  "command-line": "hippunfold [SUBJECT_DIR] [OUTPUT_DIR] participant [MODALITY] [DERIVATIVES] [SKIP_PREPROC] [SKIP_COREG] [SKIP_INJECT_TEMPLATE_LABELS] [INJECT_TEMPLATE_SMOOTHING_FACTOR] [RIGID_REG_TEMPLATE] [NO_REG_TEMPLATE] [TEMPLATE] [ATLAS] [T1_REG_TEMPLATE] [GENERATE_MYELIN_MAP] [NNUNET_ENABLE_TTA] [OUTPUT_SPACES] [OUTPUT_DENSITY] [HEMI] [LAMINAR_COORDS_METHOD] [KEEP_WORK] [FORCE_NNUNET_MODEL] -c all --nolock",
   "inputs": [
       {
         "description": "subject folder for BIDS (folders name should be sub-XXXXX).",


### PR DESCRIPTION
Default arg should be `--nolock`, instead of `--unlock`. Unlock won't actually run the workflow (will just unlock), whereas nolock will run the workflow without locking.