### PR TITLE
[FIX] multispectral and spectral_mask

### DIFF
--- a/cbrain_task/civet_macaque/bourreau/civet_macaque.rb
+++ b/cbrain_task/civet_macaque/bourreau/civet_macaque.rb
@@ -101,7 +101,7 @@ class CbrainTask::CivetMacaque < ClusterTask
     if collection
 
       return false if   !make_available_collection(collection, input_symlink_base, t1_name, "t1")
-      
+
       if mk_name.present?
         return false if !make_available_collection(collection, input_symlink_base, mk_name, "mask")
       end
@@ -221,7 +221,7 @@ class CbrainTask::CivetMacaque < ClusterTask
 
     # N3 distance
     if params[:N3_distance].present?
-      cb_error "Bad N3 distance value."  unless 
+      cb_error "Bad N3 distance value."  unless
                          is_valid_integer_list(params[:N3_distance])
     end
 
@@ -281,8 +281,8 @@ class CbrainTask::CivetMacaque < ClusterTask
     args += "-correct-pve "                                         if mybool(params[:correct_pve])
     args += "-hi-res-surfaces "                                     if mybool(params[:high_res_surfaces])
     args += "-combine-surfaces "                                    if mybool(params[:combine_surfaces])
-    args += "-multispectral "                                       if mybool(file0[:multispectral])
-    args += "-spectral_mask "                                       if mybool(file0[:spectral_mask])
+    args += "-multispectral "                                       if mybool(params[:use_multispectral] == "all")
+    args += "-spectral_mask "                                       if mybool(params[:use_spectral_mask] == "all")
 
     # PVE
     if    params[:pve] == "classic"
@@ -620,7 +620,7 @@ class CbrainTask::CivetMacaque < ClusterTask
         addlog("Resyncing input MASK ##{mk_id}.")
         SingleFile.find(mk_id).sync_to_cache
       end
-      
+
       if csf_id.present?
         addlog("Resyncing input CSF ##{csf_id}.")
         SingleFile.find(csf_id).sync_to_cache

--- a/cbrain_task/civet_macaque/bourreau/civet_macaque.rb
+++ b/cbrain_task/civet_macaque/bourreau/civet_macaque.rb
@@ -281,8 +281,8 @@ class CbrainTask::CivetMacaque < ClusterTask
     args += "-correct-pve "                                         if mybool(params[:correct_pve])
     args += "-hi-res-surfaces "                                     if mybool(params[:high_res_surfaces])
     args += "-combine-surfaces "                                    if mybool(params[:combine_surfaces])
-    args += "-multispectral "                                       if mybool(params[:use_multispectral] == "all")
-    args += "-spectral_mask "                                       if mybool(params[:use_spectral_mask] == "all")
+    args += "-multispectral "                                       if params[:use_multispectral] == "all"
+    args += "-spectral_mask "                                       if params[:use_spectral_mask] == "all"
 
     # PVE
     if    params[:pve] == "classic"

--- a/cbrain_task/civet_macaque/portal/civet_macaque.rb
+++ b/cbrain_task/civet_macaque/portal/civet_macaque.rb
@@ -138,7 +138,7 @@ class CbrainTask::CivetMacaque < PortalTask
       # select_all initial value
       :use_multispectral => "all",
       :use_spectral_mask => "all",
-      
+
     }
   end
 
@@ -250,7 +250,7 @@ class CbrainTask::CivetMacaque < PortalTask
       .each do |extracted_keyword|
         next if extracted_keyword =~ /^\{\d+\}$/
         next if allowed_keyword_filename_pattern.include?(extracted_keyword)
-        not_allowed_keywords << extracted_keyword 
+        not_allowed_keywords << extracted_keyword
     end
 
     if not_allowed_keywords.present?

--- a/cbrain_task/civet_macaque/views/_civet_macaque_file_from_list.html.erb
+++ b/cbrain_task/civet_macaque/views/_civet_macaque_file_from_list.html.erb
@@ -70,13 +70,5 @@
   <td><FONT COLOR="green">&#10004;</FONT></td>
 <% end %>
 
-<% if file[:t2_name].present? || file[:pd_name].present? %>
-  <td><div  style="display:none;"><%= form.params_check_box "file_args[#{idx}][multispectral]", :class => "use_multispectral" %></div></td>
-  <td><div  style="display:none;"><%= form.params_check_box "file_args[#{idx}][spectral_mask]", :class => "use_spectral_mask" %></div></td>
-<% else %>
-  <td></td>
-  <td></td>
-<% end %>
-
 </tr>
 

--- a/cbrain_task/civet_macaque/views/_civet_macaque_file_from_list.html.erb
+++ b/cbrain_task/civet_macaque/views/_civet_macaque_file_from_list.html.erb
@@ -70,5 +70,13 @@
   <td><FONT COLOR="green">&#10004;</FONT></td>
 <% end %>
 
+<% if file[:t2_name].present? || file[:pd_name].present? %>
+  <td><div  style="display:none;"><%= form.params_check_box "file_args[#{idx}][multispectral]", :class => "use_multispectral" %></div></td>
+  <td><div  style="display:none;"><%= form.params_check_box "file_args[#{idx}][spectral_mask]", :class => "use_spectral_mask" %></div></td>
+<% else %>
+  <td></td>
+  <td></td>
+<% end %>
+
 </tr>
 

--- a/cbrain_task/civet_macaque/views/_show_params.html.erb
+++ b/cbrain_task/civet_macaque/views/_show_params.html.erb
@@ -68,8 +68,8 @@ File collection: <%= link_to_userfile_if_accessible params[:collection_id] %>
 
     <br/>
 
-    <li>Use multispectral classification: <%= file_params[:multispectral] == "1" ? "yes" : "no" %></li>
-    <li>Use multispectral mask: <%= file_params[:spectral_mask] == "1" ? "yes" : "no" %></li>
+    <li>Use multispectral classification: <%= params[:use_multispectral] == "all" ? "yes" : "no" %></li>
+    <li>Use multispectral mask:           <%= params[:use_spectral_mask] == "all" ? "yes" : "no" %></li>
   <% end %>
   </ul>
 <% end %>

--- a/cbrain_task/civet_macaque/views/_task_params.html.erb
+++ b/cbrain_task/civet_macaque/views/_task_params.html.erb
@@ -276,6 +276,8 @@
     <th>Mask found?</th>
     <th>MP2 found?</th>
     <th>CSF found?</th>
+    <th><div style="display:none;">use_multispectral</div></th>
+    <th><div style="display:none;">use_spectral_mask</div></th>
   </tr>
   <%
     keys = params[:file_args].keys

--- a/cbrain_task/civet_macaque/views/_task_params.html.erb
+++ b/cbrain_task/civet_macaque/views/_task_params.html.erb
@@ -614,6 +614,13 @@ job's output doesn't crush another job's output!</strong>.
           disable_options(surfreg_model_values, deactivated_selector)
         }
       }
+
+      // Handle exclusion between surfreg_model and atlas (since to surfreg_model update)
+      var surfreg_model_name   = "cbrain_task[params][surfreg_model]";
+      var surfreg_model_select = $('select[name="' + surfreg_model_name + '"]')
+
+      update_according_to_surfreg(surfreg_model_select)
+      surfreg_model_select.on('change', update_according_to_surfreg);
     }
 
     var update_according_to_surfreg = (selector) => {
@@ -648,14 +655,14 @@ job's output doesn't crush another job's output!</strong>.
 
     }
 
-    // Handle expclusion between model and template
+    // Handle exclusion between model and template
     var model_name   = "cbrain_task[params][model]";
     var model_select = $('select[name="' + model_name + '"]')
 
     update_according_to_model(model_select);
     model_select.on('change', update_according_to_model);
 
-    // Handle expclusion between surfreg_model and atlas
+    // Handle exclusion between surfreg_model and atlas
     var surfreg_model_name   = "cbrain_task[params][surfreg_model]";
     var surfreg_model_select = $('select[name="' + surfreg_model_name + '"]')
 

--- a/cbrain_task/civet_macaque/views/_task_params.html.erb
+++ b/cbrain_task/civet_macaque/views/_task_params.html.erb
@@ -108,17 +108,17 @@
   <br>
 
   <%= form.params_label     :use_multispectral, "Use multispectral classification", :title => "Use multispectral classification using t2, pd if present" %>
-  <%= select_all_checkbox 'use_multispectral', 
+  <%= select_all_checkbox 'use_multispectral',
                           :checked => params[:use_multispectral] == "all" ? true : false,
-                          :persistant_name => 'use_multispectral'.to_la  
+                          :persistant_name => 'use_multispectral'.to_la
   %>
 
   <br>
 
   <%= form.params_label     :use_spectral_mask, "Use multispectral masking", :title => "Use multispectral masking using t2, pd if present" %>
-  <%= select_all_checkbox 'use_spectral_mask', 
+  <%= select_all_checkbox 'use_spectral_mask',
                           :checked => params[:use_spectral_mask] == "all" ? true : false,
-                          :persistant_name => 'use_spectral_mask'.to_la  
+                          :persistant_name => 'use_spectral_mask'.to_la
   %>
 
 
@@ -276,8 +276,6 @@
     <th>Mask found?</th>
     <th>MP2 found?</th>
     <th>CSF found?</th>
-    <th><div style="display:none;">use_multispectral</div></th>
-    <th><div style="display:none;">use_spectral_mask</div></th>
   </tr>
   <%
     keys = params[:file_args].keys
@@ -499,19 +497,19 @@ job's output doesn't crush another job's output!</strong>.
  <BIG>Fake run:</BIG><P>
  Enter the numeric ID of a pre-existing CivetOutput to use it as 'pretend' output:
  <%= form.params_text_field :fake_run_civetcollection_id %>
- 
+
 <% end %>
 
 
 
 
-# Handle option for Civet-macaque or Civet-chimp in oorder to exclude some values 
+# Handle option for Civet-macaque or Civet-chimp in oorder to exclude some values
 # when one or the the other is selected
 
 <script type="text/javascript">
 
   var options_by_model =
-    { 
+    {
       icbm152MCsym : {
         headheight       : 175,
         template         : [ '0.50', '1.0' ],
@@ -533,20 +531,20 @@ job's output doesn't crush another job's output!</strong>.
         surfreg_model    : [ 'NCBRchimp' ]
       }
     };
-  
+
   $(document).ready(function() {
-    var disable_options = (active_values        = [], 
-                           deactivated_selector = undefined, 
+    var disable_options = (active_values        = [],
+                           deactivated_selector = undefined,
                           ) => {
 
       if (deactivated_selector === undefined ) {
         return
-      } 
+      }
 
       var deactivated_current_value = deactivated_selector[0].value;
       var deactivated_options       = deactivated_selector[0].options;
 
-      // Set the value to something available 
+      // Set the value to something available
       if (!active_values.includes(deactivated_current_value)){
         var first_value_available = active_values[0] || undefined;
         var index = Array.prototype.slice.call( deactivated_options ).findIndex(o => o.value === first_value_available)
@@ -563,7 +561,7 @@ job's output doesn't crush another job's output!</strong>.
         }
       }
       deactivated_selector.trigger("chosen:updated")
-    } 
+    }
 
     var extract_current_value = (selector) => {
       var current_value = "";
@@ -573,22 +571,22 @@ job's output doesn't crush another job's output!</strong>.
         current_value = selector.val();
       }
       return current_value;
-    }; 
+    };
 
     var update_according_to_model = (selector) => {
       var current_value = extract_current_value(selector);
 
-      var model_option = options_by_model[current_value]; 
+      var model_option = options_by_model[current_value];
 
       if (model_option === undefined ) {
         return;
       }
 
-      // Update template        
+      // Update template
       var template_values = model_option['template']
-      if (template_values !== undefined) { 
+      if (template_values !== undefined) {
         var template_name        = "cbrain_task[params][template]";
-        var deactivated_selector = $('select[name="' + template_name + '"]');  
+        var deactivated_selector = $('select[name="' + template_name + '"]');
         if (deactivated_selector !== undefined) {
           disable_options(template_values, deactivated_selector)
         }
@@ -607,9 +605,9 @@ job's output doesn't crush another job's output!</strong>.
 
       // Update surfreg_model
       var surfreg_model_values = model_option['surfreg_model']
-      if (surfreg_model_values !== undefined) { 
+      if (surfreg_model_values !== undefined) {
         var surfreg_model_name        = "cbrain_task[params][surfreg_model]";
-        var deactivated_selector = $('select[name="' + surfreg_model_name + '"]');  
+        var deactivated_selector = $('select[name="' + surfreg_model_name + '"]');
         if (deactivated_selector !== undefined) {
           disable_options(surfreg_model_values, deactivated_selector)
         }
@@ -619,17 +617,17 @@ job's output doesn't crush another job's output!</strong>.
     var update_according_to_surfreg = (selector) => {
       var current_value = extract_current_value(selector);
 
-      var model_option = options_by_model[current_value]; 
+      var model_option = options_by_model[current_value];
 
       if (model_option === undefined ) {
         return;
       }
 
-      // Update atlas        
+      // Update atlas
       var atlas_values = model_option['atlas']
-      if (atlas_values !== undefined) { 
+      if (atlas_values !== undefined) {
         var atlas_name        = "cbrain_task[params][atlas]";
-        var deactivated_selector = $('select[name="' + atlas_name + '"]');  
+        var deactivated_selector = $('select[name="' + atlas_name + '"]');
         if (deactivated_selector !== undefined) {
           disable_options(atlas_values, deactivated_selector)
         }
@@ -659,7 +657,7 @@ job's output doesn't crush another job's output!</strong>.
     var surfreg_model_name   = "cbrain_task[params][surfreg_model]";
     var surfreg_model_select = $('select[name="' + surfreg_model_name + '"]')
 
-    update_according_to_surfreg(surfreg_model_select)  
+    update_according_to_surfreg(surfreg_model_select)
     surfreg_model_select.on('change', update_according_to_surfreg);
   });
 </script>


### PR DESCRIPTION
Always launch multispectral and spectral_mask if selected on the main level.

Remove the ability to select or de-select in the table.  