### PR TITLE
[UPDATE] PhysIO wrapper 1.2.0

### DIFF
--- a/boutiques_descriptors/physio_cbrain.json
+++ b/boutiques_descriptors/physio_cbrain.json
@@ -1041,7 +1041,7 @@
         "cbrain:readonly-input-files": true,
         "cbrain:integrator_modules": {
             "BoutiquesOutputFileTypeSetter": {
-                "output_folder": "PhysIOOutput"
+                "output_folder": "TapasPhysioOutput"
             }
         }
     }

--- a/boutiques_descriptors/physio_cbrain.json
+++ b/boutiques_descriptors/physio_cbrain.json
@@ -4,9 +4,10 @@
     "description": "Tapas Physio: Physiological noise correction for fMRI",
     "author": "Lars Kasper, Zurich University and ETH Zurich",
     "descriptor-url": "https://github.com/dariusvalevicius/PhysIO_CBRAIN",
+    "url": "https://github.com/translationalneuromodeling/tapas/tree/master/PhysIO",
     "command-line": "mkdir -p [OUTDIR]; physio_cbrain [USE_CASE] [FMRI_IN] [OUTDIR] [CORRECT] [log_files.align_scan] [log_files.cardiac] [log_files.cardiac_respiration] [log_files.relative_start_acquisition] [log_files.respiration] [log_files.scan_timing] [log_files.vendor] [log_files.sampling_interval] [model.censor_unreliable_recording_intervals] [model.hrv.delays] [model.hrv.include] [model.movement.censoring_method] [model.movement.censoring_threshold] [model.movement.file_realignment_parameters] [model.movement.include] [model.movement.order] [model.noise_rois.force_coregister] [model.noise_rois.include] [model.noise_rois.n_components] [model.noise_rois.n_voxel_crop] [model.noise_rois.thresholds] [model.noise_rois.fmri_files] [model.noise_rois.roi_files] [model.orthogonalise] [model.other.include] [model.other.input_multiple_regressors] [model.output_multiple_regressors] [model.output_physio] [model.retroicor.include] [model.retroicor.order.c] [model.retroicor.order.cr] [model.retroicor.order.r] [model.rvt.delays] [model.rvt.include] [preproc.cardiac.filter.passband] [preproc.cardiac.filter.type] [preproc.cardiac.initial_cpulse_select.file] [preproc.cardiac.initial_cpulse_select.max_heart_rate_bpm] [preproc.cardiac.initial_cpulse_select.method] [preproc.cardiac.initial_cpulse_select.min] [preproc.cardiac.modality] [preproc.cardiac.posthoc_cpulse_select.lower_thresh] [preproc.cardiac.posthoc_cpulse_select.method] [preproc.cardiac.posthoc_cpulse_select.file] [preproc.cardiac.posthoc_cpulse_select.percentile] [preproc.cardiac.posthoc_cpulse_select.upper_thresh] [preproc.cardiac.filter.include] [preproc.cardiac.filter.stopband] [scan_timing.sqpar.Ndummies] [scan_timing.sqpar.Nscans] [scan_timing.sqpar.Nslices] [scan_timing.sqpar.onset_slice] [scan_timing.sqpar.TR] [scan_timing.sqpar.NslicesPerBeat] [scan_timing.sqpar.time_slice_to_slice] [scan_timing.sqpar.Nprep] [scan_timing.sync.grad_direction] [scan_timing.sync.method] [scan_timing.sync.slice] [scan_timing.sync.zero] [scan_timing.sync.vol] [scan_timing.sync.vol_spacing] [verbose.fig_output_file] [verbose.level]",
     "container-image": {
-        "image": "dvalev/physio_cbrain:1.1.3",
+        "image": "dvalev/physio_cbrain:1.2.0",
         "index": "docker://",
         "type": "singularity"
     },
@@ -1037,6 +1038,11 @@
     },
     "custom": {
         "cbrain:author": "Darius Valevicius <darius.valevicius@mail.mcgill.ca>",
-        "cbrain:readonly-input-files": true
+        "cbrain:readonly-input-files": true,
+        "cbrain:integrator_modules": {
+            "BoutiquesOutputFileTypeSetter": {
+                "output_folder": "PhysIOOutput"
+            }
+        }
     }
 }

--- a/userfiles/physio_output/physio_output.rb
+++ b/userfiles/physio_output/physio_output.rb
@@ -1,0 +1,34 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# A FileCollection to model the output of a PhysIO task
+class PhysIOOutput < FileCollection
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def self.pretty_type #:nodoc:
+    "PhysIO Output"
+  end
+
+end
+
+

--- a/userfiles/tapas_physio_output/tapas_physio_output.rb
+++ b/userfiles/tapas_physio_output/tapas_physio_output.rb
@@ -21,12 +21,12 @@
 #
 
 # A FileCollection to model the output of a PhysIO task
-class PhysIOOutput < FileCollection
+class TapasPhysioOutput < FileCollection
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   def self.pretty_type #:nodoc:
-    "PhysIO Output"
+    "TAPAS PhysIO Output"
   end
 
 end


### PR DESCRIPTION
Note to Natacha - I changed the image version from 8.1.0 (physIO version) to 1.2.0 (wrapper version). I considered changing my versioning scheme to match the tool version as per Pierre's earlier comment, but finally I think it's best too keep my wrapper-based versioning scheme for my images (the tool version is still in the descriptor and that is what is shown to the user at launch).

The main changes in this patch are fixing memory issues and throwing exceptions on bad input.