### PR TITLE
Different error messages for invalid OpenNeuro dataset name or version, and for those not yet deployed on Github

### DIFF
--- a/openneuro/app/controllers/open_neuro_controller.rb
+++ b/openneuro/app/controllers/open_neuro_controller.rb
@@ -31,8 +31,12 @@ class OpenNeuroController < ApplicationController
     name    = params[:name]
     version = params[:version]
     @open_neuro = OpenNeuro.find(name,version)
-    if ! @open_neuro.valid_name_and_version?
-      message = "The OpenNeuro dataset name '#{name}' with version '#{version}' is not valid."
+    if ! @open_neuro.on_github_mirror?
+      if @open_neuro.valid_name_and_version?
+        message = "The OpenNeuro dataset name '#{name}' with version '#{version}' is not yet on Github. Please try latter or contact us."
+      else
+        message = "The OpenNeuro dataset name '#{name}' with version '#{version}' does not exists."
+      end
       flash.now[:error] = message    if ! current_user
       flash[:error]     = message    if current_user
       redirect_to :action => :select if current_user

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -310,26 +310,15 @@ class OpenNeuro
     "OpenNeuro-#{name}-#{version.gsub('.','_')}"
   end
 
-  # Validation of a pair [ dataset, version ] performed with:
+  # Validation of a pair [ dataset, version ] with OpenNeuro GraphQL API
+  #   
+  # The result is sometimes different          
+  # "https://api.github.com/repos/OpenNeuroDatasets/
   #
-  #   curl -H "Accept: application/vnd.github+json"
-  #        -H "X-GitHub-Api-Version: 2022-11-28"
-  #        "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/ref/tags/2.4.0"
-  #
-  # The typical response is like this:
-  #
-  #   {
-  #     "ref": "refs/tags/2.4.0",
-  #     "node_id": "REF_kwDOK8fpRq9yZWZzL3RhZ3MvMi40LjA",
-  #     "url": "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/refs/tags/2.4.0",
-  #     "object": {
-  #       "sha": "1aa6d3a098d16009d39adde6a7abe1c34d4b07d6",
-  #       "type": "commit",
-  #       "url": "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/commits/1aa6d3a098d16009d39adde6a7abe1c34d4b07d6"
-  #     }
-  #   }
-  #
-  # The method just returns true or false.
+  # Some datasets or dataset versions, availabe on OpenNeuro portal or with OpenNeuro client are not always
+  # on GitHub
+  #   
+  # At the moment the method just returns true or false.
   def self.valid_name_and_version?(name, version)
     return false unless name =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -149,6 +149,11 @@ class OpenNeuro
     self.class.valid_name_and_version?(self.name,self.version)
   end
 
+  # Instance method of the class method
+  def on_github_mirror?
+    self.class.on_github_mirror?(self.name,self.version)
+  end
+
   ############################################################
   # Meta data persistence helpers; here we store and retrieve
   # miscellanous values used for tracking the progres of
@@ -312,15 +317,16 @@ class OpenNeuro
 
   # Validation of a pair [ dataset, version ] with OpenNeuro GraphQL API
   #   
-  # The result is sometimes different          
+  # The result is sometimes different from
   # "https://api.github.com/repos/OpenNeuroDatasets/
   #
   # Some datasets or dataset versions, availabe on OpenNeuro portal or with OpenNeuro client are not always
   # on GitHub
   #   
   # At the moment the method just returns true or false.
+  # Failures/rate restriction of Github API are not handled
   def self.valid_name_and_version?(name, version)
-    return false unless name =~ /\Ads\d+\z/
+    return false unless name    =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/
     query = '{snapshot(datasetId:"%s", tag:"%s"){id}}' % [name, version]
 
@@ -360,7 +366,7 @@ class OpenNeuro
   #   }
   #
   # The method just returns true or false.
-  def self.valid_name_and_github_tag?(name, version)
+  def self.on_github_mirror?(name, version)
     return false unless name    =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/
 

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -332,26 +332,25 @@ class OpenNeuro
   #
   # The method just returns true or false.
   def self.valid_name_and_version?(name, version)
-    return false unless name    =~ /\Ads\d+\z/
+    return false unless name =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/
     query = '{snapshot(datasetId:"%s", tag:"%s"){id}}' % [name, version]
 
     response = Typhoeus.post(OPENNEURO_API_URL,
-                             {:body   =>  JSON.pretty_generate({"query" => query})
-                             },
-                             :headers => { :Accept       => 'application/json'    }
+                             :body    => JSON.pretty_generate({ "query" => query }),
+                             :headers => { 'Content-Type' => 'application/json',
+                                           'Accept'       => 'application/json'
+                             }
     )
 
-
     # Parse the response
-    body         = response.response_body
-    json         = JSON.parse(body)
-    return ! json["errors"]
+    body = response.response_body
+    json = JSON.parse(body)
+    return !json["errors"]
   rescue => ex
     Rails.logger.error "OpenNeuro API request failed: #{ex.class} #{ex.message}"
     return nil
   end
-
 
   # Validation of a pair [ dataset, tag ] on github performed with:
   #

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -2,7 +2,7 @@
 #
 # CBRAIN Project
 #
-# Copyright (C) 2008-2023
+# Copyright (C) 2008-2024
 # The Royal Institution for the Advancement of Learning
 # McGill University
 #
@@ -41,7 +41,6 @@ class OpenNeuro
   DATALAD_REPO_URL_PREFIX = 'https://github.com/OpenNeuroDatasets'
   GITHUB_VALIDATION_URL   = 'https://api.github.com/repos/OpenNeuroDatasets/:name/git/ref/tags/:version'
   OPENNEURO_API_URL       = 'https://openneuro.org/crn/graphql'
-
 
   # Creates an OpenNeuro object that represents
   # the dataset internally as a pair, a WorkGroup


### PR DESCRIPTION
Sometimes in OpenNeuro the most recent versions is not represented by any tag in the corresponding GitHub repository, for example [ds003194 v1.0.4] (https://openneuro.org/datasets/ds003194/versions/1.0.4 ) updated 2022-09-20 while the corresponding Github repo was last updated in 2020 and end with tag 1.0.3 . There is at least another dataset with same glitch, ds003075. More, some OpenNeuro datasets do not have a single version on  GitHub: see the [OpenNeuro](https://github.com/OpenNeuroOrg/openneuro/) issue #3037  that tracks datasets not present on GitHub.

The present message is same for both cases of mistypes version and one that is not yet present on OpenNeuro.

This PR aims to give more appropriate message for both cases.

It seems like a OpenNeuro glitch, which we should escalate to their team, but OpenNeuro 'name and version' this issues may persist for a while.

To actually allows admin to download and configure dataset on alternative github organization/username see another PR #287 

_Note_ I downloaded v.1.0.4  using OpenNeuro client, and created my version of the DataLad repo  at https://github.com/MontrealSergiy/ds003194
