### PR TITLE
Allow OpenNeuro setup from alternative GitHub urls for important datasets like ds003194

### DIFF
--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -310,26 +310,15 @@ class OpenNeuro
     "OpenNeuro-#{name}-#{version.gsub('.','_')}"
   end
 
-  # Validation of a pair [ dataset, version ] performed with:
+  # Validation of a pair [ dataset, version ] with OpenNeuro GraphQL API
+  #   
+  # The result is sometimes different          
+  # "https://api.github.com/repos/OpenNeuroDatasets/
   #
-  #   curl -H "Accept: application/vnd.github+json"
-  #        -H "X-GitHub-Api-Version: 2022-11-28"
-  #        "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/ref/tags/2.4.0"
-  #
-  # The typical response is like this:
-  #
-  #   {
-  #     "ref": "refs/tags/2.4.0",
-  #     "node_id": "REF_kwDOK8fpRq9yZWZzL3RhZ3MvMi40LjA",
-  #     "url": "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/refs/tags/2.4.0",
-  #     "object": {
-  #       "sha": "1aa6d3a098d16009d39adde6a7abe1c34d4b07d6",
-  #       "type": "commit",
-  #       "url": "https://api.github.com/repos/OpenNeuroDatasets/ds004906/git/commits/1aa6d3a098d16009d39adde6a7abe1c34d4b07d6"
-  #     }
-  #   }
-  #
-  # The method just returns true or false.
+  # Some datasets or dataset versions, availabe on OpenNeuro portal or with OpenNeuro client are not always
+  # on GitHub
+  #   
+  # At the moment the method just returns true or false.
   def self.valid_name_and_version?(name, version)
     return false unless name =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -332,26 +332,25 @@ class OpenNeuro
   #
   # The method just returns true or false.
   def self.valid_name_and_version?(name, version)
-    return false unless name    =~ /\Ads\d+\z/
+    return false unless name =~ /\Ads\d+\z/
     return false unless version =~ /\A[a-z0-9][\w\.\-]+\z/
     query = '{snapshot(datasetId:"%s", tag:"%s"){id}}' % [name, version]
 
     response = Typhoeus.post(OPENNEURO_API_URL,
-                             {:body   =>  JSON.pretty_generate({"query" => query})
-                             },
-                             :headers => { :Accept       => 'application/json'    }
+                             :body    => JSON.pretty_generate({ "query" => query }),
+                             :headers => { 'Content-Type' => 'application/json',
+                                           'Accept'       => 'application/json'
+                             }
     )
 
-
     # Parse the response
-    body         = response.response_body
-    json         = JSON.parse(body)
-    return ! json["errors"]
+    body = response.response_body
+    json = JSON.parse(body)
+    return !json["errors"]
   rescue => ex
     Rails.logger.error "OpenNeuro API request failed: #{ex.class} #{ex.message}"
     return nil
   end
-
 
   # Validation of a pair [ dataset, tag ] on github performed with:
   #

--- a/openneuro/app/models/open_neuro.rb
+++ b/openneuro/app/models/open_neuro.rb
@@ -2,7 +2,7 @@
 #
 # CBRAIN Project
 #
-# Copyright (C) 2008-2023
+# Copyright (C) 2008-2024
 # The Royal Institution for the Advancement of Learning
 # McGill University
 #
@@ -41,7 +41,6 @@ class OpenNeuro
   DATALAD_REPO_URL_PREFIX = 'https://github.com/OpenNeuroDatasets'
   GITHUB_VALIDATION_URL   = 'https://api.github.com/repos/OpenNeuroDatasets/:name/git/ref/tags/:version'
   OPENNEURO_API_URL       = 'https://openneuro.org/crn/graphql'
-
 
   # Creates an OpenNeuro object that represents
   # the dataset internally as a pair, a WorkGroup


### PR DESCRIPTION
includes some of commits of PR #286 that fix dataset name and version validation, and allows to use alternative github url/account to store OpenNeuro datalad repos, such as github.com/aces, so we have worry less of manual setup and/or datalad folder being archived, deleted etc in CBRAIN. The dataset can be retrieved with OpenNeuro cliend and then uploaded to aces or MontrealSergiy account.

