### PR TITLE
Dcm2bids scaffold

### DIFF
--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -8,7 +8,7 @@
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": "echo you [CITETOOL]d to cite dcm2bids; set  -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"",
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; SCAFFOLD=' [SCAFFOLD_DIR] '; [ \"$SCAFFOLD\" != \" -o \" ] && dcm2bids_scaffold [SCAFFOLD_DIR] [OVERWRITE]  ; set  -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [SCAFFOLD_DIR] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"",
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -17,7 +17,7 @@
   "tags": {
     "domain": [
       "NIfTI",
-      "bids",
+      "BIDS",
       "neuroimaging"
     ]
   },
@@ -40,6 +40,25 @@
       "type": "String",
       "id": "participant",
       "value-key": "[PARTICIPANT]"
+    },
+    {
+      "id": "scaffold",
+      "name": "BIDS scaffold directory",
+      "description": "Creates stab/scaffolding BIDS directory using dcm2bids_scaffold, the subject directory(-ies) will placed inside this directory.",
+      "optional": true,
+      "type": "String",
+      "value-key": "[SCAFFOLD_DIR]",
+      "command-line-flag": "-o"
+    },
+    {
+      "id": "overwrite",
+      "name": "Overwrite",
+      "description": "Force overwriting when creating scaffold.",
+      "optional": true,
+      "type": "Flag",
+      "value-key": "[OVERWRITE]",
+      "command-line-flag": "--force",
+      "requires-inputs": ["scaffold"]
     },
     {
       "description": "Session ID, e.g. 001",
@@ -159,16 +178,37 @@
       "id": "bids_subject",
       "description": "the bids subject folder sub-xxxxx",
       "list": false,
+      "optional": true,
       "path-template": "sub-[PARTICIPANT]"
     },
     {
       "name": "Output BIDS directory",
-      "id": "bids",
+      "id": "existing_bids",
       "description": "the existing bids folder or stub, where the subject will be added",
       "optional": true,
       "list": false,
       "path-template": "[OUTPUT_DIR]",
       "command-line-flag": "-o"
+    },
+    {
+      "name": "Scaffold BIDS directory",
+      "id": "scaffold_bids",
+      "description": "newly created scaffold folder, where the subject will be added",
+      "optional": true,
+      "list": false,
+      "path-template": "[SCAFFOLD_DIR]",
+      "command-line-flag": "-o"
+    }
+  ],
+  "groups": [
+    {
+      "id": "bids",
+      "name": "Write to a BIDS dataset. Otherwise, a single BIDS Subject directory will be created",
+      "members": [
+        "scaffold",
+        "output_dir"
+      ],
+      "mutually-exclusive": true
     }
   ],
   "suggested-resources": {
@@ -177,7 +217,6 @@
     "cpu-cores": 1
   },
   "custom": {
-    "cbrain:readonly-input-files": true,
     "cbrain:author": "Serge Boroday <serge.boroday@mcin.ca>",
     "cbrain:integrator_modules": {
       "BoutiquesFileTypeVerifier": {
@@ -185,10 +224,13 @@
           "DicomCollection",
           "TarArchive",
           "ZipArchive"
-        ]
+        ],
+        "config": [ "JsonFile"]
       },
       "BoutiquesOutputFileTypeSetter": {
-        "bids_subject": "BidsSubject"
+        "bids_subject": "BidsSubject",
+        "existing_bids": "BidsDataset",
+        "scaffold_bids": "BidsDataset"
       }
     }
   },

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -1,14 +1,14 @@
 {
   "name": "dcm2bids",
   "tool-version": "3.2.0",
-  "author": "Boré, Arnaud; Guay, Samuel; Bedetti, Christophe; Meisler, Steven; GuenTher, Nick",
+  "author": "Arnaud Boré, Samuel Guay, Christophe Arnaud,  Steven Meisler, Nick GuenTher",
   "online-platform-urls": [
     "https://portal.cbrain.mcgill.ca"
   ],
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": ":citing - [CITETOOL]; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -52,7 +52,7 @@
     },
     {
       "description": "JSON configuration file (create ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
-      "name": "config",
+      "name": "Configuration file",
       "command-line-flag": "-c",
       "optional": false,
       "type": "File",
@@ -98,7 +98,7 @@
     },
     {
       "description": "Overwrite previous temporary dcm2bids output if it exists.",
-      "name": "force_dcm2bids",
+      "name": "Overwrite tmp data",
       "command-line-flag": "--force_dcm2bids",
       "optional": true,
       "type": "Flag",
@@ -107,7 +107,7 @@
     },
     {
       "description": "Skip dcm2niix conversion. Option -d should contains NIFTI and json files.",
-      "name": "skip_dcm2niix",
+      "name": "Skip dcm2niix",
       "command-line-flag": "--skip_dcm2niix",
       "optional": true,
       "type": "Flag",
@@ -117,7 +117,7 @@
     },
     {
       "description": "Overwrite output if it exists.",
-      "name": "clobber",
+      "name": "Clobber",
       "command-line-flag": "--clobber",
       "optional": true,
       "type": "Flag",
@@ -143,7 +143,7 @@
     },
     {
       "description": "If you use dcm2bids in your research or as part of your developments, please always cite it",
-      "name": "agreement",
+      "name": "Agreement",
       "optional": false,
       "type": "String",
       "id": "agreement",

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -8,7 +8,7 @@
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": "echo you [CITETOOL]d to cite dcm2bids; { case '  '  in  \" [SCAFFOLD_DIR] \"*) ;; *) dcm2bids_scaffold [SCAFFOLD_DIR] [OVERWRITE]  ;; esac; set -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [SCAFFOLD_DIR] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] } | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"" ,
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; [ '  '  !=  \" [SCAFFOLD_DIR] \" ] && dcm2bids_scaffold [SCAFFOLD_DIR] [OVERWRITE] ;  dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [SCAFFOLD_DIR] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] ",
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -23,22 +23,33 @@
   },
   "inputs": [
     {
-      "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip) for given subject. Note, you might need extract subject data from large DICOM dataset, or split the dataset before with appropriate DICOM tool or library ",
+      "id": "agreement",
+      "name": "Agreement",
+      "description": "dcm2bids will be cited whenever it is used for research or as part of developments",
+      "optional": false,
+      "type": "String",
+      "value-key": "[CITETOOL]",
+      "value-choices": [
+        "agree"
+      ]
+    },
+    {
+      "id": "dicom_dir",
       "name": "DICOM subject data",
+      "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip) for given subject. Note, you might need extract subject data from large DICOM dataset, or split the dataset before with appropriate DICOM tool or library ",
       "command-line-flag": "-d",
       "optional": false,
       "list": true,
       "type": "File",
-      "id": "dicom_dir",
       "value-key": "[DICOM_DIR]"
     },
     {
-      "description": "Participant ID, e.g. 0000123",
+      "id": "participant",
       "name": "Participant ID",
+      "description": "Alphanumerical participant label, informally referred as a participant Id. Avoid overly long labels. For greater compatibility with bids validation tool use only lower case characters (if any), for example  0000123f",
       "command-line-flag": "-p",
       "optional": false,
       "type": "String",
-      "id": "participant",
       "value-key": "[PARTICIPANT]"
     },
     {
@@ -52,101 +63,106 @@
     },
     {
       "id": "overwrite",
-      "name": "Overwrite",
+      "name": "Overwrite scaffold",
       "description": "Force overwriting when creating scaffold.",
       "optional": true,
       "type": "Flag",
       "value-key": "[OVERWRITE]",
       "command-line-flag": "--force",
-      "requires-inputs": ["scaffold"]
+      "requires-inputs": [
+        "scaffold"
+      ]
     },
     {
-      "description": "Session ID, e.g. 001",
       "name": "Session ID",
+      "id": "session",
+      "description": "Session label, which is a reasonbaly short sequence of alphanumericals, possibly interleaved with underscores and hyphens, for example mri-day_1.",
       "command-line-flag": "-s",
       "optional": true,
       "type": "String",
-      "id": "session",
       "value-key": "[SESSION]"
     },
     {
-      "description": "JSON configuration file, please create and debug it ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
       "name": "Configuration file",
+      "id": "config",
+      "description": "JSON configuration file, please create and debug it ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
       "command-line-flag": "-c",
       "optional": false,
       "type": "File",
-      "id": "config",
       "value-key": "[CONFIG]"
     },
     {
-      "description": "Existing BIDS dataset or stub, provide it if you like to add a new subject into that BIDS directory",
-      "name": "Place the subject directory into this BIDS dataset or stub",
+      "id": "output_dir",
+      "name": "Preexisting BIDS dataset scaffold",
+      "description": "Existing BIDS dataset, scaffold or stub, provide it if you like to add a new subject into that BIDS directory. This is an experimental feature, may corrupt data when not used carefully. Recommended solution is create subject folders separately then combine",
       "command-line-flag": "-o",
       "optional": true,
       "type": "File",
-      "id": "output_dir",
       "value-key": "[OUTPUT_DIR]"
     },
     {
-      "description": "If set, it will automatically try to extract entity information [task, dir, echo] based on the suffix and datatype. ",
+      "id": "auto_extract_entities",
       "name": "Auto extract entities",
+      "description": "If set, it will automatically try to extract entity information [task, dir, echo] based on the suffix and datatype. ",
       "command-line-flag": "--auto_extract_entities",
       "optional": true,
       "type": "Flag",
-      "id": "auto_extract_entities",
       "value-key": "[AUTO_EXTRACT_ENTITIES]",
       "default-value": true
     },
     {
-      "description": "If set, it will not reorder entities according to the relative ordering indicated in the BIDS specification and use the order defined in custom_entities by the user.\nCannot be used with --auto_extract_entities.  [%(default)s]",
+      "id": "do_not_reorder_entities",
       "name": "Do not reorder entities",
+      "description": "If set, it will not reorder entities according to the relative ordering indicated in the BIDS specification and use the order defined in custom_entities by the user.\nCannot be used with --auto_extract_entities.  [%(default)s]",
       "command-line-flag": "--do_not_reorder_entities",
       "optional": true,
       "type": "Flag",
-      "id": "do_not_reorder_entities",
       "value-key": "[DO_NOT_REORDER_ENTITIES]"
     },
     {
-      "description": "If set, once your conversion is done it will check if your output directory is BIDS valid. ",
       "name": "BIDS validate",
+      "id": "bids_validate",
+      "description": "If set, once your conversion is done it will check if your output directory is BIDS valid. ",
       "command-line-flag": "--bids_validate",
       "optional": true,
       "type": "Flag",
-      "id": "bids_validate",
       "value-key": "[BIDS_VALIDATE]"
     },
     {
-      "description": "Overwrite previous temporary dcm2bids output if it exists.",
       "name": "Overwrite tmp data",
+      "id": "force_dcm2bids",
+      "description": "Overwrite previous temporary dcm2bids output if it exists. Experimental.",
       "command-line-flag": "--force_dcm2bids",
       "optional": true,
       "type": "Flag",
-      "id": "force_dcm2bids",
       "value-key": "[FORCE_DCM2BIDS]"
     },
     {
-      "description": "Skip dcm2niix conversion. One of directories supplied with option -d should contains NIFTI and json files.",
       "name": "Skip dcm2niix",
+      "description": "Skip dcm2niix conversion. One of directories supplied with option -d should contains NIFTI and json files.",
+      "id": "skip_dcm2niix",
       "command-line-flag": "--skip_dcm2niix",
       "optional": true,
       "type": "Flag",
-      "id": "skip_dcm2niix",
       "value-key": "[SKIP_DCM2NIIX]",
-      "requires-inputs": ["dicom_dir"]
+      "requires-inputs": [
+        "dicom_dir"
+      ]
     },
     {
-      "description": "Overwrite output if it exists.",
       "name": "Clobber",
+      "id": "clobber",
+      "description": "Overwrite output if it exists. Experimental.",
       "command-line-flag": "--clobber",
       "optional": true,
       "type": "Flag",
-      "id": "clobber",
       "value-key": "[CLOBBER]"
     },
     {
-      "default-value": "INFO",
-      "description": "Set logging level to the console.",
+      "id": "log_level",
       "name": "Log level",
+      "description": "Set logging level to the console.",
+      "default-value": "INFO",
       "value-choices": [
         "DEBUG",
         "INFO",
@@ -157,19 +173,7 @@
       "optional": true,
       "command-line-flag": "-l",
       "type": "String",
-      "id": "log_level",
       "value-key": "[LOG_LEVEL]"
-    },
-    {
-      "description": "If you use dcm2bids in your research or as part of your developments, please always cite it",
-      "name": "Agreement",
-      "optional": false,
-      "type": "String",
-      "id": "agreement",
-      "value-key": "[CITETOOL]",
-      "value-choices": [
-        "agree"
-      ]
     }
   ],
   "output-files": [
@@ -182,18 +186,9 @@
       "path-template": "sub-[PARTICIPANT]"
     },
     {
-      "name": "Output BIDS directory",
-      "id": "existing_bids",
-      "description": "the existing bids directory or stub, where the subject will be added, resulting a new dataset",
-      "optional": true,
-      "list": false,
-      "path-template": "[OUTPUT_DIR]",
-      "command-line-flag": "-o"
-    },
-    {
       "name": "Scaffold BIDS directory",
       "id": "scaffold_bids",
-      "description": "newly created scaffold directory, where the subject will be added",
+      "description": "Newly created BIDS dataset scaffold directory, where the subject directory added",
       "optional": true,
       "list": false,
       "path-template": "[SCAFFOLD_DIR]",
@@ -218,6 +213,7 @@
   },
   "custom": {
     "cbrain:author": "Serge Boroday <serge.boroday@mcin.ca>",
+    "cbrain:save_back_inputs" : ["output_dir"],
     "cbrain:integrator_modules": {
       "BoutiquesFileTypeVerifier": {
         "dicom_dir": [
@@ -225,15 +221,19 @@
           "TarArchive",
           "ZipArchive"
         ],
-        "config": [ "JsonFile"]
+        "config": [
+          "JsonFile"
+        ]
       },
       "BoutiquesOutputFileTypeSetter": {
         "bids_subject": "BidsSubject",
         "existing_bids": "BidsDataset",
         "scaffold_bids": "BidsDataset"
       },
-      "BoutiquesFileNameMatcher": {
-        "scaffold": "^[a-zA-Z0-9_\\+=\\-]{0,63}$"
+      "BoutiquesInputRegexChecker": {
+        "scaffold": "^[a-zA-Z0-9_\\+=\\-]{0,63}$",
+        "participant": "^[a-zA-Z0-9]{1,255}$",
+        "session": "^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$"
       }
     }
   },

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -1,14 +1,26 @@
 {
-  "description": "DICOM to BIDS converter",
-  "command-line": "dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
-  "tags":  {
+  "name": "dcm2bids",
+  "tool-version": "3.2.0",
+  "author": "Boré, Arnaud; Guay, Samuel; Bedetti, Christophe; Meisler, Steven; GuenTher, Nick",
+  "online-platform-urls": [
+    "https://portal.cbrain.mcgill.ca"
+  ],
+  "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
+  "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
+  "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
+  "command-line": ":citing - [CITETOOL]; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
+  "container-image": {
+    "index": "docker://",
+    "image": "unfmontreal/dcm2bids:3.2.0",
+    "type": "singularity"
+  },
+  "tags": {
     "domain": [
-      "nifti",
+      "NIfTI",
       "bids",
-      "neuro-imaging"
+      "neuroimaging"
     ]
   },
-  "tool-version": "3.2.0",
   "inputs": [
     {
       "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip).",
@@ -16,7 +28,7 @@
       "command-line-flag": "-d",
       "optional": false,
       "list": true,
-      "type": "String",
+      "type": "File",
       "id": "dicom_dir",
       "value-key": "[DICOM_DIR]"
     },
@@ -39,20 +51,20 @@
       "value-key": "[SESSION]"
     },
     {
-      "description": "JSON configuration file (see manual online https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
+      "description": "JSON configuration file (create on according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
       "name": "config",
       "command-line-flag": "-c",
       "optional": false,
-      "type": "String",
+      "type": "File",
       "id": "config",
       "value-key": "[CONFIG]"
     },
     {
-      "description": "Output BIDS directory. [%(default)s]",
+      "description": "BIDS directory, provide it if you like to add a new subject to be added to a BIDS directory",
       "name": "output_dir",
       "command-line-flag": "-o",
       "optional": true,
-      "type": "String",
+      "type": "File",
       "id": "output_dir",
       "value-key": "[OUTPUT_DIR]"
     },
@@ -63,7 +75,8 @@
       "optional": true,
       "type": "Flag",
       "id": "auto_extract_entities",
-      "value-key": "[AUTO_EXTRACT_ENTITIES]"
+      "value-key": "[AUTO_EXTRACT_ENTITIES]",
+      "default-value": true
     },
     {
       "description": "If set, it will not reorder entities according to the relative ordering indicated in the BIDS specification and use the order defined in custom_entities by the user.\nCannot be used with --auto_extract_entities.  [%(default)s]",
@@ -75,7 +88,7 @@
       "value-key": "[DO_NOT_REORDER_ENTITIES]"
     },
     {
-      "description": "If set, once your conversion is done it will check if your output folder is BIDS valid. [%(default)s]\nbids-validator needs to be installed check: https://github.com/bids-standard/bids-validator#quickstart",
+      "description": "If set, once your conversion is done it will check if your output folder is BIDS valid. ",
       "name": "bids_validate",
       "command-line-flag": "--bids_validate",
       "optional": true,
@@ -102,7 +115,7 @@
       "value-key": "[SKIP_DCM2NIIX]"
     },
     {
-      "description": "Overwrite output if it exists.",
+      "description": "Overwrite output if it exists (currently not-applicable).",
       "name": "clobber",
       "command-line-flag": "--clobber",
       "optional": true,
@@ -135,6 +148,35 @@
       "type": "String",
       "id": "version",
       "value-key": "[VERSION]"
+    },
+    {
+      "description": "If you use dcm2bids in your research or as part of your developments, please always cite it",
+      "name": "agreement",
+      "optional": false,
+      "type": "String",
+      "id": "agreement",
+      "value-key": "[CITETOOL]",
+      "value-choices": [
+        "agree"
+      ]
+    }
+  ],
+  "output-files": [
+    {
+      "name": "Output BIDS SUBJECT directory",
+      "id": "bids_subject",
+      "description": "the bids subject folder sub-xxxxx",
+      "list": false,
+      "path-template": "sub-[PARTICIPANT]"
+    },
+    {
+      "name": "Output BIDS directory",
+      "id": "bids",
+      "description": "the bids subject folder sub-xxxxx",
+      "optional": false,
+      "list": false,
+      "path-template": "[OUTPUT_DIR]",
+      "command-line-flag": "-o"
     }
   ],
   "suggested-resources": {
@@ -142,6 +184,21 @@
     "walltime-estimate": 24000,
     "cpu-cores": 1
   },
-  "name": "dcm2bids",
+  "custom": {
+    "cbrain:readonly-input-files": true,
+    "cbrain:author": "Serge Boroday <serge.boroday@mcin.ca>",
+    "cbrain:integrator_modules": {
+      "BoutiquesFileTypeVerifier": {
+        "dicom_dir": [
+          "DicomCollection",
+          "TarArchive",
+          "ZipArchive"
+        ]
+      },
+      "BoutiquesOutputFileTypeSetter": {
+        "bids_subject": "BidsSubject"
+      }
+    }
+  },
   "schema-version": "0.5"
 }

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -8,7 +8,7 @@
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": "echo you [CITETOOL]d to cite dcm2bids; SCAFFOLD=' [SCAFFOLD_DIR] '; [ \"$SCAFFOLD\" != \" -o \" ] && dcm2bids_scaffold [SCAFFOLD_DIR] [OVERWRITE]  ; set  -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [SCAFFOLD_DIR] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"",
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; { case '  '  in  \" [SCAFFOLD_DIR] \"*) ;; *) dcm2bids_scaffold [SCAFFOLD_DIR] [OVERWRITE]  ;; esac; set -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [SCAFFOLD_DIR] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] } | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"" ,
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -107,7 +107,7 @@
       "value-key": "[DO_NOT_REORDER_ENTITIES]"
     },
     {
-      "description": "If set, once your conversion is done it will check if your output folder is BIDS valid. ",
+      "description": "If set, once your conversion is done it will check if your output directory is BIDS valid. ",
       "name": "BIDS validate",
       "command-line-flag": "--bids_validate",
       "optional": true,
@@ -176,7 +176,7 @@
     {
       "name": "Output BIDS SUBJECT directory",
       "id": "bids_subject",
-      "description": "the bids subject folder sub-xxxxx",
+      "description": "the bids subject directory sub-xxxxx",
       "list": false,
       "optional": true,
       "path-template": "sub-[PARTICIPANT]"
@@ -184,7 +184,7 @@
     {
       "name": "Output BIDS directory",
       "id": "existing_bids",
-      "description": "the existing bids folder or stub, where the subject will be added",
+      "description": "the existing bids directory or stub, where the subject will be added, resulting a new dataset",
       "optional": true,
       "list": false,
       "path-template": "[OUTPUT_DIR]",
@@ -193,7 +193,7 @@
     {
       "name": "Scaffold BIDS directory",
       "id": "scaffold_bids",
-      "description": "newly created scaffold folder, where the subject will be added",
+      "description": "newly created scaffold directory, where the subject will be added",
       "optional": true,
       "list": false,
       "path-template": "[SCAFFOLD_DIR]",
@@ -231,6 +231,9 @@
         "bids_subject": "BidsSubject",
         "existing_bids": "BidsDataset",
         "scaffold_bids": "BidsDataset"
+      },
+      "BoutiquesFileNameMatcher": {
+        "scaffold": "^[a-zA-Z0-9_\\+=\\-]{0,63}$"
       }
     }
   },

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -8,7 +8,7 @@
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": "echo you [CITETOOL]d to cite dcm2bids; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL]",
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; set  -o pipefail; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] | sed -r \"s/\\x1B\\[[0-9;]*[mK]//g\"",
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -106,7 +106,7 @@
       "value-key": "[FORCE_DCM2BIDS]"
     },
     {
-      "description": "Skip dcm2niix conversion. Option -d should contains NIFTI and json files.",
+      "description": "Skip dcm2niix conversion. One of directories supplied with option -d should contains NIFTI and json files.",
       "name": "Skip dcm2niix",
       "command-line-flag": "--skip_dcm2niix",
       "optional": true,

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -23,8 +23,8 @@
   },
   "inputs": [
     {
-      "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip).",
-      "name": "dicom_dir",
+      "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip) for given subject. Note, you might need extract subject data from large DICOM dataset, or split the dataset before with appropriate DICOM tool or library ",
+      "name": "DICOM subject data",
       "command-line-flag": "-d",
       "optional": false,
       "list": true,
@@ -33,8 +33,8 @@
       "value-key": "[DICOM_DIR]"
     },
     {
-      "description": "Participant ID",
-      "name": "participant",
+      "description": "Participant ID, e.g. 0000123",
+      "name": "Participant ID",
       "command-line-flag": "-p",
       "optional": false,
       "type": "String",
@@ -42,8 +42,8 @@
       "value-key": "[PARTICIPANT]"
     },
     {
-      "description": "Session ID",
-      "name": "session",
+      "description": "Session ID, e.g. 001",
+      "name": "Session ID",
       "command-line-flag": "-s",
       "optional": true,
       "type": "String",
@@ -51,7 +51,7 @@
       "value-key": "[SESSION]"
     },
     {
-      "description": "JSON configuration file (create on according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
+      "description": "JSON configuration file (create ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
       "name": "config",
       "command-line-flag": "-c",
       "optional": false,
@@ -60,8 +60,8 @@
       "value-key": "[CONFIG]"
     },
     {
-      "description": "BIDS directory, provide it if you like to add a new subject to be added to a BIDS directory",
-      "name": "output_dir",
+      "description": "Existing BIDS dataset or stub, provide it if you like to add a new subject into that BIDS directory",
+      "name": "Place the subject directory into this BIDS dataset or stub",
       "command-line-flag": "-o",
       "optional": true,
       "type": "File",
@@ -70,7 +70,7 @@
     },
     {
       "description": "If set, it will automatically try to extract entity information [task, dir, echo] based on the suffix and datatype. ",
-      "name": "auto_extract_entities",
+      "name": "Auto extract entities",
       "command-line-flag": "--auto_extract_entities",
       "optional": true,
       "type": "Flag",
@@ -80,7 +80,7 @@
     },
     {
       "description": "If set, it will not reorder entities according to the relative ordering indicated in the BIDS specification and use the order defined in custom_entities by the user.\nCannot be used with --auto_extract_entities.  [%(default)s]",
-      "name": "do_not_reorder_entities",
+      "name": "Do not reorder entities",
       "command-line-flag": "--do_not_reorder_entities",
       "optional": true,
       "type": "Flag",
@@ -89,7 +89,7 @@
     },
     {
       "description": "If set, once your conversion is done it will check if your output folder is BIDS valid. ",
-      "name": "bids_validate",
+      "name": "BIDS validate",
       "command-line-flag": "--bids_validate",
       "optional": true,
       "type": "Flag",
@@ -112,10 +112,11 @@
       "optional": true,
       "type": "Flag",
       "id": "skip_dcm2niix",
-      "value-key": "[SKIP_DCM2NIIX]"
+      "value-key": "[SKIP_DCM2NIIX]",
+      "requires-inputs": ["dicom_dir"]
     },
     {
-      "description": "Overwrite output if it exists (currently not-applicable).",
+      "description": "Overwrite output if it exists.",
       "name": "clobber",
       "command-line-flag": "--clobber",
       "optional": true,
@@ -126,7 +127,7 @@
     {
       "default-value": "INFO",
       "description": "Set logging level to the console.",
-      "name": "log_level",
+      "name": "Log level",
       "value-choices": [
         "DEBUG",
         "INFO",
@@ -172,8 +173,8 @@
     {
       "name": "Output BIDS directory",
       "id": "bids",
-      "description": "the bids subject folder sub-xxxxx",
-      "optional": false,
+      "description": "the existing bids folder or stub, where the subject will be added",
+      "optional": true,
       "list": false,
       "path-template": "[OUTPUT_DIR]",
       "command-line-flag": "-o"

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -142,15 +142,6 @@
       "value-key": "[LOG_LEVEL]"
     },
     {
-      "description": "Report dcm2bids version and the BIDS version.",
-      "name": "version",
-      "command-line-flag": "-v",
-      "optional": true,
-      "type": "String",
-      "id": "version",
-      "value-key": "[VERSION]"
-    },
-    {
       "description": "If you use dcm2bids in your research or as part of your developments, please always cite it",
       "name": "agreement",
       "optional": false,

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -8,7 +8,7 @@
   "url": "https://unfmontreal.github.io/Dcm2Bids/3.2.0/",
   "descriptor-url": "https://github.com/aces/cbrain-plugins-neuro/blob/master/boutiques_descriptors/dcm2bids_3_2.json",
   "description": "DICOM to BIDS converter. dcm2bids reorganises NIfTI files using dcm2niix into the Brain Imaging Data Structure (BIDS). dcm2bids>=3.0.0 is not compatible with config files made for v2.1.9 ",
-  "command-line": "echo you [CITETOOL]d to cite dcm2bids; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
+  "command-line": "echo you [CITETOOL]d to cite dcm2bids; dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL]",
   "container-image": {
     "index": "docker://",
     "image": "unfmontreal/dcm2bids:3.2.0",
@@ -51,7 +51,7 @@
       "value-key": "[SESSION]"
     },
     {
-      "description": "JSON configuration file (create ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
+      "description": "JSON configuration file, please create and debug it ahead according to manual at https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
       "name": "Configuration file",
       "command-line-flag": "-c",
       "optional": false,

--- a/boutiques_descriptors/dcm2bids_3_2.json
+++ b/boutiques_descriptors/dcm2bids_3_2.json
@@ -1,0 +1,147 @@
+{
+  "description": "DICOM to BIDS converter",
+  "command-line": "dcm2bids [DICOM_DIR] [PARTICIPANT] [SESSION] [CONFIG] [OUTPUT_DIR] [AUTO_EXTRACT_ENTITIES] [DO_NOT_REORDER_ENTITIES] [BIDS_VALIDATE] [FORCE_DCM2BIDS] [SKIP_DCM2NIIX] [CLOBBER] [LOG_LEVEL] [VERSION]",
+  "tags":  {
+    "domain": [
+      "nifti",
+      "bids",
+      "neuro-imaging"
+    ]
+  },
+  "tool-version": "3.2.0",
+  "inputs": [
+    {
+      "description": "DICOM directory(ies) or archive(s) (tar, tar.bz2, tar.gz or zip).",
+      "name": "dicom_dir",
+      "command-line-flag": "-d",
+      "optional": false,
+      "list": true,
+      "type": "String",
+      "id": "dicom_dir",
+      "value-key": "[DICOM_DIR]"
+    },
+    {
+      "description": "Participant ID",
+      "name": "participant",
+      "command-line-flag": "-p",
+      "optional": false,
+      "type": "String",
+      "id": "participant",
+      "value-key": "[PARTICIPANT]"
+    },
+    {
+      "description": "Session ID",
+      "name": "session",
+      "command-line-flag": "-s",
+      "optional": true,
+      "type": "String",
+      "id": "session",
+      "value-key": "[SESSION]"
+    },
+    {
+      "description": "JSON configuration file (see manual online https://unfmontreal.github.io/Dcm2Bids/3.2.0/how-to/create-config-file/ ",
+      "name": "config",
+      "command-line-flag": "-c",
+      "optional": false,
+      "type": "String",
+      "id": "config",
+      "value-key": "[CONFIG]"
+    },
+    {
+      "description": "Output BIDS directory. [%(default)s]",
+      "name": "output_dir",
+      "command-line-flag": "-o",
+      "optional": true,
+      "type": "String",
+      "id": "output_dir",
+      "value-key": "[OUTPUT_DIR]"
+    },
+    {
+      "description": "If set, it will automatically try to extract entity information [task, dir, echo] based on the suffix and datatype. ",
+      "name": "auto_extract_entities",
+      "command-line-flag": "--auto_extract_entities",
+      "optional": true,
+      "type": "Flag",
+      "id": "auto_extract_entities",
+      "value-key": "[AUTO_EXTRACT_ENTITIES]"
+    },
+    {
+      "description": "If set, it will not reorder entities according to the relative ordering indicated in the BIDS specification and use the order defined in custom_entities by the user.\nCannot be used with --auto_extract_entities.  [%(default)s]",
+      "name": "do_not_reorder_entities",
+      "command-line-flag": "--do_not_reorder_entities",
+      "optional": true,
+      "type": "Flag",
+      "id": "do_not_reorder_entities",
+      "value-key": "[DO_NOT_REORDER_ENTITIES]"
+    },
+    {
+      "description": "If set, once your conversion is done it will check if your output folder is BIDS valid. [%(default)s]\nbids-validator needs to be installed check: https://github.com/bids-standard/bids-validator#quickstart",
+      "name": "bids_validate",
+      "command-line-flag": "--bids_validate",
+      "optional": true,
+      "type": "Flag",
+      "id": "bids_validate",
+      "value-key": "[BIDS_VALIDATE]"
+    },
+    {
+      "description": "Overwrite previous temporary dcm2bids output if it exists.",
+      "name": "force_dcm2bids",
+      "command-line-flag": "--force_dcm2bids",
+      "optional": true,
+      "type": "Flag",
+      "id": "force_dcm2bids",
+      "value-key": "[FORCE_DCM2BIDS]"
+    },
+    {
+      "description": "Skip dcm2niix conversion. Option -d should contains NIFTI and json files.",
+      "name": "skip_dcm2niix",
+      "command-line-flag": "--skip_dcm2niix",
+      "optional": true,
+      "type": "Flag",
+      "id": "skip_dcm2niix",
+      "value-key": "[SKIP_DCM2NIIX]"
+    },
+    {
+      "description": "Overwrite output if it exists.",
+      "name": "clobber",
+      "command-line-flag": "--clobber",
+      "optional": true,
+      "type": "Flag",
+      "id": "clobber",
+      "value-key": "[CLOBBER]"
+    },
+    {
+      "default-value": "INFO",
+      "description": "Set logging level to the console.",
+      "name": "log_level",
+      "value-choices": [
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL"
+      ],
+      "optional": true,
+      "command-line-flag": "-l",
+      "type": "String",
+      "id": "log_level",
+      "value-key": "[LOG_LEVEL]"
+    },
+    {
+      "description": "Report dcm2bids version and the BIDS version.",
+      "name": "version",
+      "command-line-flag": "-v",
+      "optional": true,
+      "type": "String",
+      "id": "version",
+      "value-key": "[VERSION]"
+    }
+  ],
+  "suggested-resources": {
+    "ram": 1,
+    "walltime-estimate": 24000,
+    "cpu-cores": 1
+  },
+  "name": "dcm2bids",
+  "schema-version": "0.5"
+}


### PR DESCRIPTION
The suggested version has option to generated 

1) only single subject directory
2) generate a scaffolding with a single subject with in
3) add new subject to an existing bids dataset (scaffolding/stub) 

If 3 option seems too much, I would keep just the first one, or split into several separate tools


It does not support handling DICOM dataset with many subjects (but might be provided with Extended CBRAIN File List)