### PR TITLE
improve FastSurfer sid option verbiage, auto recognize subj

### DIFF
--- a/boutiques_descriptors/fastsurfer_cpu_2_4_2.json
+++ b/boutiques_descriptors/fastsurfer_cpu_2_4_2.json
@@ -25,9 +25,10 @@
             "id": "subject_id",
             "name": "Subject ID",
             "type": "String",
-            "description": "Subject ID to create directory inside SUBJECTS_DIR",
+            "description": "Output folder to be created (typically based on Subject ID)",
             "command-line-flag": "--sid",
             "value-key": "[SUBJECT_ID]",
+            "default-value": "{1}-{2}",
             "optional": false
         },
         {
@@ -156,7 +157,7 @@
         {
             "id": "output_dir",
             "name": "Output Directory",
-            "description": "The output directory containing all FastSurfer results",
+            "description": "The results",
             "path-template": "[SUBJECT_ID]",
             "optional": false,
             "value-key": "[RESULTS]"
@@ -235,6 +236,12 @@
             "BoutiquesFileNameMatcher": {
                 "t1_input": "\\.nii(\\.gz)?$|\\.mg(z|h)$",
                 "t2_input": "\\.nii(\\.gz)?$|\\.mg(z|h)$"
+            },
+            "BoutiquesOutputFilenameRenamer": {
+                "output_dir": [
+                    "t1_input",
+                    "subject_id"
+                ]
             },
             "BoutiquesFileTypeVerifier": {
                 "t1_input": ["NiftiFile", "MghFile", "SingleFile"],

--- a/boutiques_descriptors/fastsurfer_cpu_2_4_2.json
+++ b/boutiques_descriptors/fastsurfer_cpu_2_4_2.json
@@ -157,7 +157,7 @@
         {
             "id": "output_dir",
             "name": "Output Directory",
-            "description": "The results",
+            "description": "The output directory containing all FastSurfer results",
             "path-template": "[SUBJECT_ID]",
             "optional": false,
             "value-key": "[RESULTS]"

--- a/boutiques_descriptors/fastsurfer_cuda_2_4_2.json
+++ b/boutiques_descriptors/fastsurfer_cuda_2_4_2.json
@@ -25,7 +25,7 @@
             "id": "subject_id",
             "name": "Subject ID",
             "type": "String",
-            "description": "Subject ID to create directory inside SUBJECTS_DIR",
+            "description": "Output folder to be created (typically based on Subject ID)",
             "command-line-flag": "--sid",
             "value-key": "[SUBJECT_ID]",
             "optional": false
@@ -156,7 +156,7 @@
         {
             "id": "output_dir",
             "name": "Output Directory",
-            "description": "The output directory containing all FastSurfer results",
+            "description": "The results",
             "path-template": "[SUBJECT_ID]",
             "optional": false,
             "value-key": "[RESULTS]"
@@ -236,6 +236,12 @@
             "BoutiquesFileNameMatcher": {
                 "t1_input": "\\.nii(\\.gz)?$|\\.mg(z|h)$",
                 "t2_input": "\\.nii(\\.gz)?$|\\.mg(z|h)$"
+            },
+            "BoutiquesOutputFilenameRenamer": {
+                "output_dir": [
+                    "t1_input",
+                    "subject_id"
+                ]
             },
             "BoutiquesFileTypeVerifier": {
                 "t1_input": ["NiftiFile", "MghFile", "SingleFile"],

--- a/boutiques_descriptors/fastsurfer_cuda_2_4_2.json
+++ b/boutiques_descriptors/fastsurfer_cuda_2_4_2.json
@@ -156,7 +156,7 @@
         {
             "id": "output_dir",
             "name": "Output Directory",
-            "description": "The results",
+            "description": "The output directory containing all FastSurfer results",
             "path-template": "[SUBJECT_ID]",
             "optional": false,
             "value-key": "[RESULTS]"


### PR DESCRIPTION
During recent meeting, requester (Naj and Guan) expressed some criticism toward subject id option.

This PR offers more CBRAIN user friendly verbiage instead of verbatim copy of tool man/help option description. Also 'OutputRenamer' module is added to recognise subject label/identifier.

Also default value is proved