### PR TITLE
better error message when FS license is erroneously registered as text file

### DIFF
--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,6 +60,26 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
+    # by default CBRAIN assign license.txt file Text File type, lets tell user set type properly
+    if lic.blank? && params[:interface_userfile_ids].size > 1
+      txt_lic = TextFile
+        .where(
+          user_id: self.user_id,
+          id:      params[:interface_userfile_ids],
+          name:    "license.txt"
+        )
+        .order(updated_at: :desc)
+        .first
+
+      if txt_lic.present?
+        cb_error(
+          "Suspicious license.txt file is registered/uploaded as Text File. " \
+            "If it is a FreeSurfer license, please change its type accordingly " \
+            "and try again. (Or provide another valid license file with its type properly set.)"
+        )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
+      end
+    end
+
     # Find a license among all files owned by the user
     lic ||= FreesurferLicense
       .where(:user_id => self.user_id)

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,8 +60,8 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
-    # by default CBRAIN assign license.txt file Text File type, lets tell user set type properly
-    if lic.blank? && params[:interface_userfile_ids].size > 1
+    # by default CBRAIN assign license.txt file Text File type, lets tell user reassign type properly
+    if lic.blank?
       txt_lic = TextFile
         .where(
           id:      params[:interface_userfile_ids],
@@ -77,6 +77,7 @@ module BoutiquesFreesurferLicenseFinder
             "and try again. (Or provide another valid license file with its type properly set.)"
         )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
       end
+      # a user may accidentally supply license of another user, we do not prohibit users from sharing any files, or check license content
     end
 
     # Find a license among all files owned by the user

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -64,7 +64,6 @@ module BoutiquesFreesurferLicenseFinder
     if lic.blank? && params[:interface_userfile_ids].size > 1
       txt_lic = TextFile
         .where(
-          user_id: self.user_id,
           id:      params[:interface_userfile_ids],
           name:    "license.txt"
         )


### PR DESCRIPTION
By default, CBRAIN sets the `license.txt` file type to **Text File**. When a user supplies a FreeSurfer `license.txt` file, a misleading error message is produced, as FS License module finds and appends additionally, a FreeLicense type file. 

IMHO depending on number of a tool optional input files a tool has, the consequences could be even worse, but did not try.

This PR should address the problem

See also [preliminary discussion](https://github.com/aces/cbrain/issues/1642)