### PR TITLE
Free Surfer License Finder should quit quietly when a file name resembles a license

### DIFF
--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,6 +60,26 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
+    # by default CBRAIN assign license.txt file Text File type, lets tell user set type properly
+    if lic.blank? && params[:interface_userfile_ids].size > 1
+      txt_lic = TextFile
+        .where(
+          user_id: self.user_id,
+          id:      params[:interface_userfile_ids],
+          name:    "license.txt"
+        )
+        .order(updated_at: :desc)
+        .first
+
+      if txt_lic.present?
+        cb_error(
+          "Suspicious license.txt file is registered/uploaded as Text File. " \
+            "If it is a FreeSurfer license, please change its type accordingly " \
+            "and try again. (Or provide another valid license file with its type properly set.)"
+        )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
+      end
+    end
+
     # Find a license among all files owned by the user
     lic ||= FreesurferLicense
       .where(:user_id => self.user_id)

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,8 +60,8 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
-    # by default CBRAIN assign license.txt file Text File type, lets tell user set type properly
-    if lic.blank? && params[:interface_userfile_ids].size > 1
+    # by default CBRAIN assign license.txt file Text File type, lets tell user reassign type properly
+    if lic.blank?
       txt_lic = TextFile
         .where(
           id:      params[:interface_userfile_ids],
@@ -77,6 +77,7 @@ module BoutiquesFreesurferLicenseFinder
             "and try again. (Or provide another valid license file with its type properly set.)"
         )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
       end
+      # a user may accidentally supply license of another user, we do not prohibit users from sharing any files, or check license content
     end
 
     # Find a license among all files owned by the user

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -64,7 +64,6 @@ module BoutiquesFreesurferLicenseFinder
     if lic.blank? && params[:interface_userfile_ids].size > 1
       txt_lic = TextFile
         .where(
-          user_id: self.user_id,
           id:      params[:interface_userfile_ids],
           name:    "license.txt"
         )

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,7 +60,9 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
-    # by default CBRAIN assign license.txt file Text File type, lets tell user reassign type properly
+    # By default, CBRAIN assigns license.txt as Text File.
+    # Therefore, we prompt users to set the correct type for FreeSurfer licenses.
+
     if lic.blank?
       txt_lic = TextFile
         .where(
@@ -77,7 +79,8 @@ module BoutiquesFreesurferLicenseFinder
             "and try again. (Or provide another valid license file with its type properly set.)"
         )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
       end
-      # a user may accidentally supply license of another user, we do not prohibit users from sharing any files, or check license content
+      # a user may accidentally supply license of another user, we neither prohibit users from sharing any files
+      # nor check license content
     end
 
     # Find a license among all files owned by the user

--- a/lib/boutiques_freesurfer_license_finder.rb
+++ b/lib/boutiques_freesurfer_license_finder.rb
@@ -60,28 +60,16 @@ module BoutiquesFreesurferLicenseFinder
       .order("updated_at desc")
       .first
 
-    # By default, CBRAIN assigns license.txt as Text File.
-    # Therefore, we prompt users to set the correct type for FreeSurfer licenses.
-
-    if lic.blank?
-      txt_lic = TextFile
+    # a user may accidentally supply his own or another user's Text file license
+    # We neither prohibit users from sharing any files
+    # nor check license content for licensee email, and this is
+    # a convenience rather than validation module
+    return super if lic.blank? && Userfile
         .where(
           id:      params[:interface_userfile_ids],
-          name:    "license.txt"
-        )
-        .order(updated_at: :desc)
-        .first
-
-      if txt_lic.present?
-        cb_error(
-          "Suspicious license.txt file is registered/uploaded as Text File. " \
-            "If it is a FreeSurfer license, please change its type accordingly " \
-            "and try again. (Or provide another valid license file with its type properly set.)"
-        )   # the phrase in brackets addresses a hypothetical case of a tool with two licenses
-      end
-      # a user may accidentally supply license of another user, we neither prohibit users from sharing any files
-      # nor check license content
-    end
+          type:    "TextFile")  # other classes, such as Single File are extremely rare for FS license
+        .where("name LIKE ?", "%license%")
+        .exists?
 
     # Find a license among all files owned by the user
     lic ||= FreesurferLicense


### PR DESCRIPTION
The previous PR #394 has been adjusted so that it no longer produces warnings or error messages following critique at  https://github.com/aces/cbrain-plugins-neuro/pull/394#issuecomment-5038584936. 

In fact Error message might be a false alarm, as FreeSurfer license is not strictly tied to one user, so one group may share same license. The number of users in license body is merely an estimate.

The original issue was reported in aces/cbrain/#1642. While basing any logic on file name is not ideal, I believe this PR,  is better than introducing license-specific logic into the supposedly domain-neutral main repository and easier than creating additional modules or renaming existing one. 